### PR TITLE
Clarify find_references tool description

### DIFF
--- a/README.md
+++ b/README.md
@@ -390,11 +390,11 @@ Find the definition of a symbol by name and kind in a file. Returns definitions 
 
 ### `find_references`
 
-Find all references to a symbol by name and kind in a file. Returns references for all matching symbols.
+Find all references to a symbol across the entire workspace. Returns references for all matching symbols.
 
 **Parameters:**
 
-- `file_path`: The path to the file
+- `file_path`: The path to the file where the symbol is defined
 - `symbol_name`: The name of the symbol
 - `symbol_kind`: The kind of symbol (function, class, variable, method, etc.) (optional)
 - `include_declaration`: Whether to include the declaration (optional, default: true)

--- a/index.ts
+++ b/index.ts
@@ -70,13 +70,13 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
       {
         name: 'find_references',
         description:
-          'Find all references to a symbol by name and kind in a file. Returns references for all matching symbols.',
+          'Find all references to a symbol across the entire workspace. Returns references for all matching symbols.',
         inputSchema: {
           type: 'object',
           properties: {
             file_path: {
               type: 'string',
-              description: 'The path to the file',
+              description: 'The path to the file where the symbol is defined',
             },
             symbol_name: {
               type: 'string',


### PR DESCRIPTION
## Clarify find_references tool description

### Problem
The tool description was ambiguous about which file path to provide. When Claude Code tried to use this tool, it first provided a file that imported and used the symbol, which returned "No symbols found". It only worked when providing the file where the symbol was actually defined.

### Solution
Made the requirements explicit:
- Description: "Find all references to a symbol **across the entire workspace**"
- `file_path` parameter: "The path to the file **where the symbol is defined**"

### Changes
- Updated `index.ts` and `README.md` for consistency

### Impact
Prevents failed tool calls by clarifying upfront that the tool needs the definition file, not any file that uses the symbol.