### PR TITLE
🐛 fix: select most specific LSP server based on rootDir

### DIFF
--- a/src/server-selection.test.ts
+++ b/src/server-selection.test.ts
@@ -1,0 +1,198 @@
+import { beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { existsSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { LSPClient } from './lsp-client.js';
+
+const TEST_DIR = process.env.RUNNER_TEMP
+  ? `${process.env.RUNNER_TEMP}/cclsp-server-selection-test`
+  : '/tmp/cclsp-server-selection-test';
+
+const TEST_CONFIG_PATH = join(TEST_DIR, 'test-config.json');
+
+describe('LSPClient server selection', () => {
+  beforeEach(() => {
+    // Clean up test directory
+    if (existsSync(TEST_DIR)) {
+      rmSync(TEST_DIR, { recursive: true, force: true });
+    }
+    mkdirSync(TEST_DIR, { recursive: true });
+  });
+
+  it('should select single matching server', () => {
+    const testConfig = {
+      servers: [
+        {
+          extensions: ['ts'],
+          command: ['typescript-language-server', '--stdio'],
+          rootDir: '.',
+        },
+      ],
+    };
+
+    writeFileSync(TEST_CONFIG_PATH, JSON.stringify(testConfig));
+    const client = new LSPClient(TEST_CONFIG_PATH);
+
+    // Access private method for testing
+    const getServerForFile = (client as any).getServerForFile.bind(client);
+    const server = getServerForFile('/some/path/test.ts');
+
+    expect(server).toBeTruthy();
+    expect(server.extensions).toContain('ts');
+  });
+
+  it('should select most specific rootDir when multiple servers match extension', () => {
+    const testConfig = {
+      servers: [
+        {
+          extensions: ['ts'],
+          command: ['server-root', '--stdio'],
+          rootDir: '.',
+        },
+        {
+          extensions: ['ts'],
+          command: ['server-specific', '--stdio'],
+          rootDir: 'repos/applicationserver',
+        },
+      ],
+    };
+
+    writeFileSync(TEST_CONFIG_PATH, JSON.stringify(testConfig));
+    const client = new LSPClient(TEST_CONFIG_PATH);
+    const getServerForFile = (client as any).getServerForFile.bind(client);
+
+    // File inside repos/applicationserver should use the more specific server
+    const cwd = process.cwd();
+    const server = getServerForFile(join(cwd, 'repos/applicationserver/src/test.ts'));
+
+    expect(server).toBeTruthy();
+    expect(server.command[0]).toBe('server-specific');
+  });
+
+  it('should fall back to less specific rootDir when file is outside specific rootDir', () => {
+    const testConfig = {
+      servers: [
+        {
+          extensions: ['ts'],
+          command: ['server-root', '--stdio'],
+          rootDir: '.',
+        },
+        {
+          extensions: ['ts'],
+          command: ['server-specific', '--stdio'],
+          rootDir: 'repos/applicationserver',
+        },
+      ],
+    };
+
+    writeFileSync(TEST_CONFIG_PATH, JSON.stringify(testConfig));
+    const client = new LSPClient(TEST_CONFIG_PATH);
+    const getServerForFile = (client as any).getServerForFile.bind(client);
+
+    // File outside repos/applicationserver should use root server
+    const cwd = process.cwd();
+    const server = getServerForFile(join(cwd, 'other-dir/test.ts'));
+
+    expect(server).toBeTruthy();
+    expect(server.command[0]).toBe('server-root');
+  });
+
+  it('should handle absolute paths in rootDir', () => {
+    const testConfig = {
+      servers: [
+        {
+          extensions: ['ts'],
+          command: ['server-absolute', '--stdio'],
+          rootDir: '/absolute/path/to/project',
+        },
+      ],
+    };
+
+    writeFileSync(TEST_CONFIG_PATH, JSON.stringify(testConfig));
+    const client = new LSPClient(TEST_CONFIG_PATH);
+    const getServerForFile = (client as any).getServerForFile.bind(client);
+
+    const server = getServerForFile('/absolute/path/to/project/src/test.ts');
+
+    expect(server).toBeTruthy();
+    expect(server.command[0]).toBe('server-absolute');
+  });
+
+  it('should return first match when no rootDir contains the file', () => {
+    const testConfig = {
+      servers: [
+        {
+          extensions: ['ts'],
+          command: ['server-one', '--stdio'],
+          rootDir: 'project-a',
+        },
+        {
+          extensions: ['ts'],
+          command: ['server-two', '--stdio'],
+          rootDir: 'project-b',
+        },
+      ],
+    };
+
+    writeFileSync(TEST_CONFIG_PATH, JSON.stringify(testConfig));
+    const client = new LSPClient(TEST_CONFIG_PATH);
+    const getServerForFile = (client as any).getServerForFile.bind(client);
+
+    // File outside both rootDirs should fall back to first match
+    const server = getServerForFile('/completely/different/path/test.ts');
+
+    expect(server).toBeTruthy();
+    expect(server.command[0]).toBe('server-one');
+  });
+
+  it('should return null when no server matches extension', () => {
+    const testConfig = {
+      servers: [
+        {
+          extensions: ['ts'],
+          command: ['typescript-language-server', '--stdio'],
+          rootDir: '.',
+        },
+      ],
+    };
+
+    writeFileSync(TEST_CONFIG_PATH, JSON.stringify(testConfig));
+    const client = new LSPClient(TEST_CONFIG_PATH);
+    const getServerForFile = (client as any).getServerForFile.bind(client);
+
+    const server = getServerForFile('/some/path/test.py');
+
+    expect(server).toBeNull();
+  });
+
+  it('should prefer longer matching rootDir over shorter one', () => {
+    const testConfig = {
+      servers: [
+        {
+          extensions: ['ts'],
+          command: ['server-short', '--stdio'],
+          rootDir: 'repos',
+        },
+        {
+          extensions: ['ts'],
+          command: ['server-long', '--stdio'],
+          rootDir: 'repos/applicationserver',
+        },
+        {
+          extensions: ['ts'],
+          command: ['server-longest', '--stdio'],
+          rootDir: 'repos/applicationserver/apps',
+        },
+      ],
+    };
+
+    writeFileSync(TEST_CONFIG_PATH, JSON.stringify(testConfig));
+    const client = new LSPClient(TEST_CONFIG_PATH);
+    const getServerForFile = (client as any).getServerForFile.bind(client);
+
+    const cwd = process.cwd();
+    const server = getServerForFile(join(cwd, 'repos/applicationserver/apps/infinity/src/test.ts'));
+
+    expect(server).toBeTruthy();
+    expect(server.command[0]).toBe('server-longest');
+  });
+});


### PR DESCRIPTION
## Problem

Fixes #23

When multiple LSP servers support the same file extension with different `rootDir` values (common in monorepos), cclsp was selecting the first matching server regardless of which workspace the file belongs to.

## Root Cause

The `getServerForFile()` method used first-match logic based only on file extension:
```typescript
const server = this.config.servers.find((server) => server.extensions.includes(extension));
```

This ignored the `rootDir` configuration entirely.

## Solution

When multiple servers match a file's extension, now selects the server whose `rootDir` most specifically contains the file (longest matching path). This ensures each file is analyzed by the correct workspace-aware LSP server.

**Example:**
```json
{
  "servers": [
    { "extensions": ["ts"], "command": ["ts-server"], "rootDir": "." },
    { "extensions": ["ts"], "command": ["ts-server"], "rootDir": "repos/app" }
  ]
}
```

File at `repos/app/src/test.ts` → Uses server with `rootDir: "repos/app"` (more specific)  
File at `other/test.ts` → Uses server with `rootDir: "."` (fallback)

## Changes

- Updated `getServerForFile()` to select based on most specific `rootDir`
- Added comprehensive tests for server selection logic
- Maintains backwards compatibility with single-server configurations

## Testing

✅ All existing tests pass (158 tests)  
✅ Added 7 new test cases for server selection  
✅ Linting and type checking pass  

```bash
bun test src/server-selection.test.ts
 7 pass
 0 fail
```