### PR TITLE
feat: add new LSP tools (hover, workspace_symbol, find_implementation…

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -168,3 +168,37 @@ export interface DocumentDiagnosticReport {
   resultId?: string;
   items?: Diagnostic[];
 }
+
+// Call Hierarchy types
+export interface CallHierarchyItem {
+  name: string;
+  kind: SymbolKind;
+  tags?: SymbolTag[];
+  detail?: string;
+  uri: string;
+  range: {
+    start: Position;
+    end: Position;
+  };
+  selectionRange: {
+    start: Position;
+    end: Position;
+  };
+  data?: unknown;
+}
+
+export interface CallHierarchyIncomingCall {
+  from: CallHierarchyItem;
+  fromRanges: Array<{
+    start: Position;
+    end: Position;
+  }>;
+}
+
+export interface CallHierarchyOutgoingCall {
+  to: CallHierarchyItem;
+  fromRanges: Array<{
+    start: Position;
+    end: Position;
+  }>;
+}


### PR DESCRIPTION
feat: add 6 new LSP tools
Add the following new MCP tools to match Claude Code's built-in LSP capabilities:

- get_hover: Get hover information (documentation, type info) for a symbol
- find_workspace_symbols: Search for symbols across the entire workspace
- find_implementation: Find implementations of interfaces/abstract methods
- prepare_call_hierarchy: Get call hierarchy item at a position
- get_incoming_calls: Find all callers of a function
- get_outgoing_calls: Find all functions called by a function

Changes:
- src/types.ts: Add CallHierarchyItem, CallHierarchyIncomingCall, CallHierarchyOutgoingCall types
- src/lsp-client.ts: Add hover(), workspaceSymbol(), findImplementation(), prepareCallHierarchy(), incomingCalls(), outgoingCalls() methods
- index.ts: Add MCP tool definitions and handlers for all new tools