### PR TITLE
feat: add tool filtering via cclsp.json config

### DIFF
--- a/src/lsp-client.ts
+++ b/src/lsp-client.ts
@@ -109,6 +109,14 @@ export class LSPClient {
     }
   }
 
+  /**
+   * Returns the tools configuration from cclsp.json.
+   * Used to filter which MCP tools are exposed.
+   */
+  get tools(): Record<string, boolean> | undefined {
+    return this.config.tools;
+  }
+
   private getServerForFile(filePath: string): LSPServerConfig | null {
     const extension = filePath.split('.').pop();
     if (!extension) return null;

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,24 @@ export interface LSPServerConfig {
 
 export interface Config {
   servers: LSPServerConfig[];
+  /**
+   * Map of tool names to enabled status.
+   * If a tool is not listed, it defaults to enabled.
+   * Set to `false` to disable a specific tool.
+   *
+   * @example
+   * ```json
+   * {
+   *   "tools": {
+   *     "rename_symbol": true,
+   *     "find_references": true,
+   *     "find_definition": false,
+   *     "get_diagnostics": false
+   *   }
+   * }
+   * ```
+   */
+  tools?: Record<string, boolean>;
 }
 
 export interface Position {


### PR DESCRIPTION
## Summary

This PR adds the ability to enable/disable specific MCP tools through the `tools` field in `cclsp.json`.

**Problem:** Currently, all 12 tools are always exposed, which can clutter the context window when only a few tools are needed.

**Solution:** Allow users to configure which tools are enabled via config:

```json
{
  "tools": {
    "rename_symbol": true,
    "find_references": true,
    "find_definition": false,
    "get_diagnostics": false,
    "get_hover": false,
    "find_workspace_symbols": false,
    "find_implementation": false,
    "prepare_call_hierarchy": false,
    "get_incoming_calls": false,
    "get_outgoing_calls": false,
    "rename_symbol_strict": false,
    "restart_server": false
  },
  "servers": [...]
}
```

- Tools not listed default to **enabled** (backward compatible)
- Tools set to `false` are not exposed via `ListTools`
- Calling a disabled tool returns a helpful error message

## Changes

- `src/types.ts`: Added `tools?: Record<string, boolean>` to `Config` interface
- `src/lsp-client.ts`: Added public getter for `tools` config
- `index.ts`: Extracted tool definitions to `ALL_TOOLS` constant and filter in `ListToolsRequestSchema` handler