### PR TITLE
feat: add include_context option to return source code with results

### DIFF
--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
+import {
+  getCodeContext,
+  formatLocationWithContext,
+  pathToUri,
+  uriToPath,
+} from './utils.js';
+
+describe('utils', () => {
+  describe('pathToUri and uriToPath', () => {
+    it('should convert path to URI and back', () => {
+      const testPath = '/Users/test/file.ts';
+      const uri = pathToUri(testPath);
+      expect(uri).toBe('file:///Users/test/file.ts');
+      expect(uriToPath(uri)).toBe(testPath);
+    });
+  });
+
+  describe('getCodeContext', () => {
+    let testDir: string;
+    let testFile: string;
+
+    beforeEach(() => {
+      testDir = join(tmpdir(), `cclsp-test-${Date.now()}`);
+      mkdirSync(testDir, { recursive: true });
+      testFile = join(testDir, 'test.ts');
+    });
+
+    afterEach(() => {
+      rmSync(testDir, { recursive: true, force: true });
+    });
+
+    it('should return context around a target line', () => {
+      const content = `line 0
+line 1
+line 2
+line 3
+line 4
+line 5`;
+      writeFileSync(testFile, content);
+
+      const result = getCodeContext(testFile, 2, { linesBefore: 1, linesAfter: 1 });
+
+      expect(result).not.toBeNull();
+      expect(result!.lines).toHaveLength(3);
+      expect(result!.lines[0]!.lineNumber).toBe(2);
+      expect(result!.lines[0]!.content).toBe('line 1');
+      expect(result!.lines[0]!.isTargetLine).toBe(false);
+      expect(result!.lines[1]!.lineNumber).toBe(3);
+      expect(result!.lines[1]!.content).toBe('line 2');
+      expect(result!.lines[1]!.isTargetLine).toBe(true);
+      expect(result!.lines[2]!.lineNumber).toBe(4);
+      expect(result!.lines[2]!.content).toBe('line 3');
+      expect(result!.lines[2]!.isTargetLine).toBe(false);
+    });
+
+    it('should handle first line with context', () => {
+      const content = `first line
+second line
+third line`;
+      writeFileSync(testFile, content);
+
+      const result = getCodeContext(testFile, 0, { linesBefore: 2, linesAfter: 1 });
+
+      expect(result).not.toBeNull();
+      expect(result!.lines).toHaveLength(2);
+      expect(result!.lines[0]!.lineNumber).toBe(1);
+      expect(result!.lines[0]!.isTargetLine).toBe(true);
+      expect(result!.lines[1]!.lineNumber).toBe(2);
+    });
+
+    it('should handle last line with context', () => {
+      const content = `first line
+second line
+third line`;
+      writeFileSync(testFile, content);
+
+      const result = getCodeContext(testFile, 2, { linesBefore: 1, linesAfter: 2 });
+
+      expect(result).not.toBeNull();
+      expect(result!.lines).toHaveLength(2);
+      expect(result!.lines[0]!.lineNumber).toBe(2);
+      expect(result!.lines[1]!.lineNumber).toBe(3);
+      expect(result!.lines[1]!.isTargetLine).toBe(true);
+    });
+
+    it('should use default context lines', () => {
+      const content = `0
+1
+2
+3
+4
+5
+6`;
+      writeFileSync(testFile, content);
+
+      const result = getCodeContext(testFile, 3);
+
+      expect(result).not.toBeNull();
+      expect(result!.lines).toHaveLength(5); // 2 before + target + 2 after
+      expect(result!.lines[2]!.isTargetLine).toBe(true);
+    });
+
+    it('should return null for non-existent file', () => {
+      const result = getCodeContext('/non/existent/file.ts', 0);
+      expect(result).toBeNull();
+    });
+
+    it('should format output with line numbers and marker', () => {
+      const content = `function foo() {
+  const x = 1;
+  return x;
+}`;
+      writeFileSync(testFile, content);
+
+      const result = getCodeContext(testFile, 1, { linesBefore: 1, linesAfter: 1 });
+
+      expect(result).not.toBeNull();
+      expect(result!.formatted).toContain('> 2 |   const x = 1;');
+      expect(result!.formatted).toContain('  1 | function foo()');
+      expect(result!.formatted).toContain('  3 |   return x;');
+    });
+  });
+
+  describe('formatLocationWithContext', () => {
+    let testDir: string;
+    let testFile: string;
+
+    beforeEach(() => {
+      testDir = join(tmpdir(), `cclsp-test-${Date.now()}`);
+      mkdirSync(testDir, { recursive: true });
+      testFile = join(testDir, 'test.ts');
+    });
+
+    afterEach(() => {
+      rmSync(testDir, { recursive: true, force: true });
+    });
+
+    it('should return just location when include_context is false', () => {
+      const result = formatLocationWithContext(testFile, 10, 5, false);
+      expect(result).toBe(`${testFile}:10:5`);
+    });
+
+    it('should include context when include_context is true', () => {
+      const content = `line 1
+line 2
+line 3
+line 4
+line 5`;
+      writeFileSync(testFile, content);
+
+      const result = formatLocationWithContext(testFile, 3, 1, true, {
+        linesBefore: 1,
+        linesAfter: 1,
+      });
+
+      expect(result).toContain(`${testFile}:3:1`);
+      expect(result).toContain('line 2');
+      expect(result).toContain('> 3 | line 3');
+      expect(result).toContain('line 4');
+    });
+
+    it('should handle non-existent file gracefully', () => {
+      const result = formatLocationWithContext('/non/existent/file.ts', 10, 5, true);
+      expect(result).toBe('/non/existent/file.ts:10:5');
+    });
+  });
+});

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'node:fs';
 import { fileURLToPath, pathToFileURL } from 'node:url';
 
 /**
@@ -14,4 +15,113 @@ export function pathToUri(filePath: string): string {
  */
 export function uriToPath(uri: string): string {
   return fileURLToPath(uri);
+}
+
+/**
+ * Options for getting code context around a location
+ */
+export interface CodeContextOptions {
+  /** Number of lines to include before the target line (default: 2) */
+  linesBefore?: number;
+  /** Number of lines to include after the target line (default: 2) */
+  linesAfter?: number;
+}
+
+/**
+ * Result of getting code context
+ */
+export interface CodeContextResult {
+  /** The context lines with their line numbers */
+  lines: Array<{
+    lineNumber: number;
+    content: string;
+    isTargetLine: boolean;
+  }>;
+  /** Formatted string representation of the context */
+  formatted: string;
+}
+
+/**
+ * Get code context around a specific line in a file.
+ * Returns the target line plus surrounding context lines.
+ *
+ * @param filePath - Path to the file
+ * @param line - 0-indexed line number
+ * @param options - Context options (linesBefore, linesAfter)
+ * @returns CodeContextResult with lines and formatted output, or null if file can't be read
+ */
+export function getCodeContext(
+  filePath: string,
+  line: number,
+  options: CodeContextOptions = {}
+): CodeContextResult | null {
+  const { linesBefore = 2, linesAfter = 2 } = options;
+
+  try {
+    const content = readFileSync(filePath, 'utf-8');
+    const allLines = content.split('\n');
+
+    const startLine = Math.max(0, line - linesBefore);
+    const endLine = Math.min(allLines.length - 1, line + linesAfter);
+
+    const lines: CodeContextResult['lines'] = [];
+
+    for (let i = startLine; i <= endLine; i++) {
+      const lineContent = allLines[i];
+      if (lineContent !== undefined) {
+        lines.push({
+          lineNumber: i + 1, // 1-indexed for display
+          content: lineContent,
+          isTargetLine: i === line,
+        });
+      }
+    }
+
+    // Format the context with line numbers and a marker for the target line
+    const maxLineNumWidth = String(endLine + 1).length;
+    const formatted = lines
+      .map((l) => {
+        const lineNum = String(l.lineNumber).padStart(maxLineNumWidth, ' ');
+        const marker = l.isTargetLine ? '>' : ' ';
+        return `${marker} ${lineNum} | ${l.content}`;
+      })
+      .join('\n');
+
+    return { lines, formatted };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Format a location result with optional code context.
+ *
+ * @param filePath - Path to the file
+ * @param line - 1-indexed line number (as returned by LSP)
+ * @param character - 1-indexed character position
+ * @param includeContext - Whether to include code context
+ * @param contextOptions - Options for context (linesBefore, linesAfter)
+ * @returns Formatted location string, optionally with code context
+ */
+export function formatLocationWithContext(
+  filePath: string,
+  line: number,
+  character: number,
+  includeContext: boolean,
+  contextOptions: CodeContextOptions = {}
+): string {
+  const location = `${filePath}:${line}:${character}`;
+
+  if (!includeContext) {
+    return location;
+  }
+
+  // Line is 1-indexed from LSP, convert to 0-indexed for getCodeContext
+  const context = getCodeContext(filePath, line - 1, contextOptions);
+
+  if (!context) {
+    return location;
+  }
+
+  return `${location}\n${context.formatted}`;
 }


### PR DESCRIPTION
## Summary

This PR adds optional `include_context` and `context_lines` parameters to location-returning tools. When enabled, results include surrounding source code lines with the target line marked, reducing the need for separate file reads when Claude Code uses cclsp.

**Tools updated:**
- `find_definition`
- `find_references`
- `find_workspace_symbols`
- `find_implementation`
- `get_incoming_calls`
- `get_outgoing_calls`

**New parameters:**
- `include_context` (boolean, default: false) - Whether to include source code context
- `context_lines` (number, default: 2) - Lines of context before and after target

**Example output with context:**
```
/path/to/file.ts:42:5
  40 | function foo() {
  41 |   const x = 1;
> 42 |   return x;
  43 | }
```

## Motivation

When Claude Code uses cclsp to find definitions or references, it typically needs to make a follow-up Read call to see the actual code at each location. By including context directly in the response, we can eliminate these extra round-trips, making code navigation faster and more efficient.

## Test plan

- [x] Added unit tests for `getCodeContext()` and `formatLocationWithContext()` in `src/utils.test.ts`
- [x] All existing tests pass
- [x] TypeScript compiles without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)