### PR TITLE
fix: dispose LSP children on MCP stdio close (#47)

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -67,6 +67,21 @@ process.on('SIGTERM', () => {
   process.exit(0);
 });
 
+// Handle MCP stdio transport close. The MCP protocol's standard shutdown
+// signal is stdin close on the stdio transport, not POSIX signals. Without
+// these handlers, parent disconnect (e.g. `claude -p` exit) leaves cclsp
+// and its spawned LSP children orphaned, accumulating memory across
+// long-running parent sessions. See issue #47.
+process.stdin.on('close', () => {
+  lspClient.dispose();
+  process.exit(0);
+});
+
+process.stdin.on('end', () => {
+  lspClient.dispose();
+  process.exit(0);
+});
+
 async function main() {
   const transport = new StdioServerTransport();
   await server.connect(transport);


### PR DESCRIPTION
Fixes #47.

## Summary

Adds `process.stdin` `close` and `end` handlers in `index.ts` that mirror the existing SIGTERM handler. Without these, when the parent MCP client (e.g. `claude -p`) exits and closes the stdio transport, cclsp keeps running and its spawned LSP children (pylsp, typescript-language-server) become orphaned. On Windows this accumulates to OOM-class memory pressure across long-running parent sessions.

## Change

```diff
 process.on('SIGTERM', () => {
   lspClient.dispose();
   process.exit(0);
 });

+process.stdin.on('close', () => {
+  lspClient.dispose();
+  process.exit(0);
+});
+
+process.stdin.on('end', () => {
+  lspClient.dispose();
+  process.exit(0);
+});
```

`lspClient.dispose()` already cleans up LSP children correctly (delegates to `ServerManager.dispose()` in `src/lsp/`). The only missing piece was invoking it on the stdio-close path.

## Test plan

- [x] `bun test` — 218 pass, 9 skip, 0 fail
- [x] Manual smoke: with the patched build, fire many `claude -p` calls in a loop in a Python-heavy workspace, then enumerate orphan python.exe processes whose command line contains `pylsp` — should be 0 (was ~100 before the patch).

Happy to iterate if you'd prefer a different shape (e.g., `transport.onclose` instead of `process.stdin.on('close')`) — both achieve the same thing and I went with the `process.stdin` form to mirror the surrounding signal handlers. Let me know.