### PR TITLE
feat: add get_workspace_diagnostics MCP tool (multi-file / glob / workspace diagnostics)

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ https://github.com/user-attachments/assets/52980f32-64d6-4b78-9cbf-18d6ae120cdd
   - [`rename_symbol`](#rename_symbol)
   - [`rename_symbol_strict`](#rename_symbol_strict)
   - [`get_diagnostics`](#get_diagnostics)
+  - [`get_workspace_diagnostics`](#get_workspace_diagnostics)
   - [`restart_server`](#restart_server)
 - [💡 Real-world Examples](#-real-world-examples)
   - [Finding Function Definitions](#finding-function-definitions)
@@ -434,6 +435,83 @@ Get language diagnostics (errors, warnings, hints) for a file. Uses LSP textDocu
 
 **Parameters:**
 - `file_path`: The path to the file to get diagnostics for
+
+### `get_workspace_diagnostics`
+
+Get diagnostics across many files in one call. Designed for cleanup workflows where an agent needs an inventory of warnings and errors across the codebase. Uses LSP `workspace/diagnostic` when the server supports it, otherwise falls back to per-file pull or `didOpen` + `publishDiagnostics`. Diagnostics are bucketed by responsible LSP server and run in parallel against a single shared wall-clock budget; partial results are reported with a clear cap-hit header instead of an error.
+
+**Parameters:**
+
+- `paths`: Explicit list of file paths. May be combined with `patterns`; the final file set is the union (optional)
+- `patterns`: Glob patterns relative to `root`. Negation entries beginning with `!` are subtracted from the matched set (negation does NOT remove explicit `paths` entries) (optional)
+- `root`: Root directory for `patterns` resolution and workspace-scope walking (optional, default: process cwd)
+- `respect_gitignore`: Honor `.gitignore` when resolving `patterns` and walking the workspace (optional, default: true)
+- `include_unopened`: If false, only return diagnostics for files already open in their LSP server. With workspace scope, forces per-file pull mode against open files only (optional, default: true)
+- `min_severity`: One of `error`, `warning`, `information`, `hint`. Defaults to `warning` for cleanup workflows — use `error` to focus on errors only (optional, default: `warning`)
+- `sources`: Whitelist of diagnostic sources, e.g. `["typescript", "eslint"]` (optional)
+- `exclude_codes`: Blacklist of diagnostic codes in string form (optional)
+- `max_files`: Cap on the number of files inspected. Excess files are dropped before any LSP request (optional, default: 1000, min: 1, max: 10000)
+- `max_diagnostics`: Cap on the number of diagnostics rendered. Highest-severity entries win (optional, default: 500, min: 1, max: 5000)
+- `max_bytes`: Hard limit on rendered output size. Oversized `by_file` output auto-falls back to `summary` (optional, default: 32768, min: 1024, max: 524288)
+- `time_budget_ms`: Wall-clock budget for the whole call across every bucket (optional, default: 30000, min: 1000, max: 120000)
+- `format`: One of `summary`, `by_file`, `flat`, `json` (optional, default: `by_file`)
+- `group_by`: One of `file`, `code`, `source`, `severity` (optional, default: `file`)
+
+`paths` and `patterns` may both be supplied; the resulting file set is the union, and negation entries in `patterns` only filter pattern-resolved entries (explicit `paths` always survive). If both are absent the call uses whole-workspace scope.
+
+**Usage examples:**
+
+Get diagnostics for three specific files:
+
+```json
+{
+  "paths": [
+    "src/foo.ts",
+    "src/bar.py",
+    "src/baz.go"
+  ],
+  "min_severity": "warning"
+}
+```
+
+Glob pattern across the TypeScript surface, excluding tests:
+
+```json
+{
+  "patterns": [
+    "src/**/*.ts",
+    "!src/**/*.test.ts"
+  ],
+  "min_severity": "error"
+}
+```
+
+Whole-workspace scope (no `paths`, no `patterns`). The wall-clock budget applies, and a partial result may be returned if the budget or another cap is hit:
+
+```json
+{
+  "min_severity": "warning",
+  "time_budget_ms": 30000
+}
+```
+
+**Cap-hit messaging:**
+
+The tool never returns an error result for cap hits — instead, the header reports a `PARTIAL` status with one or more cap reasons (`BUDGET`, `MAX_FILES`, `MAX_DIAGNOSTICS`, `MAX_BYTES`, `SERVER_CRASH`) and the explicit guidance "do NOT retry with the same args — narrow scope":
+
+```
+get_workspace_diagnostics — PARTIAL
+[!] Wall-clock budget exhausted (BUDGET): 30000 ms reached after collecting 312/?? diagnostics across 47/?? files.
+[!] do NOT retry with the same args — narrow scope (use `paths` or `patterns`, or raise `time_budget_ms` up to 120000).
+```
+
+```
+get_workspace_diagnostics — PARTIAL
+[!] Diagnostic cap hit (MAX_DIAGNOSTICS): 500/1247 diagnostics rendered (highest severity first).
+[!] do NOT retry with the same args — narrow scope (raise `min_severity` to `error`, or narrow `paths`).
+```
+
+When you see a cap-hit banner, do NOT retry the same arguments — instead, narrow the scope with `paths`/`patterns`, raise `min_severity`, or raise the relevant cap up to its documented maximum.
 
 ### `restart_server`
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -13,6 +13,10 @@ Make cclsp the go-to MCP server for Language Server Protocol integration, enabli
 - ✅ TypeScript/JavaScript support out of the box
 - ✅ Basic error handling and logging
 
+## Recently Shipped
+
+- ✅ `get_workspace_diagnostics` — batch diagnostics across many files in one call, with globs, time budgets, cap-hit banners, and LSP `workspace/diagnostic` result-id reuse for fast repeat calls.
+
 ## Short-term Goals (Next 3 months)
 
 ### v1.1 - Enhanced Language Support

--- a/bun.lock
+++ b/bun.lock
@@ -9,12 +9,14 @@
         "@types/inquirer": "^9.0.8",
         "ignore": "^7.0.5",
         "inquirer": "^12.6.3",
+        "picomatch": "^4.0.4",
         "typescript-language-server": "^4.3.4",
       },
       "devDependencies": {
         "@biomejs/biome": "^1.9.4",
         "@types/bun": "latest",
         "@types/node": "^24.0.1",
+        "@types/picomatch": "^4.0.3",
         "memfs": "^4.36.3",
       },
       "peerDependencies": {
@@ -88,6 +90,8 @@
     "@types/inquirer": ["@types/inquirer@9.0.8", "", { "dependencies": { "@types/through": "*", "rxjs": "^7.2.0" } }, "sha512-CgPD5kFGWsb8HJ5K7rfWlifao87m4ph8uioU7OTncJevmE/VLIqAAjfQtko578JZg7/f69K4FgqYym3gNr7DeA=="],
 
     "@types/node": ["@types/node@24.0.1", "", { "dependencies": { "undici-types": "~7.8.0" } }, "sha512-MX4Zioh39chHlDJbKmEgydJDS3tspMP/lnQC67G3SWsTnb9NeYVWOjkxpOSy4oMfPs4StcWHwBrvUb4ybfnuaw=="],
+
+    "@types/picomatch": ["@types/picomatch@4.0.3", "", {}, "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ=="],
 
     "@types/through": ["@types/through@0.0.33", "", { "dependencies": { "@types/node": "*" } }, "sha512-HsJ+z3QuETzP3cswwtzt2vEIiHBk/dCcHGhbmG5X3ecnwFD/lPrMpliGXxSCg03L9AhrdwA4Oz/qfspkDW+xGQ=="],
 
@@ -240,6 +244,8 @@
     "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "path-to-regexp": ["path-to-regexp@8.2.0", "", {}, "sha512-TdrF7fW9Rphjq4RjrW0Kp2AW0Ahwu9sRGTkS6bvDi0SCwZlEZYmcfDbEsTz8RVk0EHIS/Vd1bv3JhG+1xZuAyQ=="],
+
+    "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "pkce-challenge": ["pkce-challenge@5.0.0", "", {}, "sha512-ueGLflrrnvwB3xuo/uGob5pd5FN7l0MsLf0Z87o/UQmRtwjvfylfc9MurIxRAWywCYTgrvpXBcqjV4OfCYGCIQ=="],
 

--- a/package.json
+++ b/package.json
@@ -52,12 +52,14 @@
     "@types/inquirer": "^9.0.8",
     "ignore": "^7.0.5",
     "inquirer": "^12.6.3",
+    "picomatch": "^4.0.4",
     "typescript-language-server": "^4.3.4"
   },
   "devDependencies": {
     "@biomejs/biome": "^1.9.4",
     "@types/bun": "latest",
     "@types/node": "^24.0.1",
+    "@types/picomatch": "^4.0.3",
     "memfs": "^4.36.3"
   },
   "peerDependencies": {

--- a/src/file-glob.test.ts
+++ b/src/file-glob.test.ts
@@ -1,0 +1,203 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { resolveFiles } from './file-glob.js';
+
+/**
+ * Tests for src/file-glob.ts.
+ *
+ * IMPORTANT: This file uses `Bun.write` for file content and
+ * `fs.promises.mkdir` for directories instead of `node:fs` writeFileSync
+ * because `src/setup.test.ts` process-globally replaces `node:fs` via
+ * `mock.module('node:fs', ...)`. Using `Bun.write` bypasses the mock.
+ * The same hazard is documented in `src/lsp/document-manager.test.ts`.
+ */
+
+/** Write a file using Bun.write to avoid node:fs mock interference. */
+async function writeFile(path: string, content: string): Promise<void> {
+  await Bun.write(path, content);
+}
+
+describe('resolveFiles', () => {
+  let TEST_DIR: string;
+
+  beforeEach(async () => {
+    TEST_DIR = mkdtempSync(join(tmpdir(), 'cclsp-file-glob-'));
+    // Create a small tree.
+    await mkdir(join(TEST_DIR, 'src'), { recursive: true });
+    await mkdir(join(TEST_DIR, 'src/sub'), { recursive: true });
+    await mkdir(join(TEST_DIR, 'dist'), { recursive: true });
+    await mkdir(join(TEST_DIR, 'node_modules'), { recursive: true });
+
+    await writeFile(join(TEST_DIR, 'src/a.ts'), 'a');
+    await writeFile(join(TEST_DIR, 'src/b.ts'), 'b');
+    await writeFile(join(TEST_DIR, 'src/c.js'), 'c');
+    await writeFile(join(TEST_DIR, 'src/sub/d.ts'), 'd');
+    await writeFile(join(TEST_DIR, 'dist/out.js'), 'out');
+    await writeFile(join(TEST_DIR, 'node_modules/lib.js'), 'lib');
+    await writeFile(join(TEST_DIR, 'README.md'), 'readme');
+    await writeFile(join(TEST_DIR, '.gitignore'), 'dist/\n');
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('matches positive picomatch patterns', async () => {
+    const r = await resolveFiles({
+      patterns: ['src/**/*.ts'],
+      root: TEST_DIR,
+      respectGitignore: false,
+      includeUnopened: true,
+      maxFiles: 100,
+    });
+    const rel = r.files.map((f) => f.replace(TEST_DIR, '')).sort();
+    expect(rel).toEqual([join('/src', 'a.ts'), join('/src', 'b.ts'), join('/src', 'sub', 'd.ts')]);
+  });
+
+  it('subtracts negation entries (! prefix) from the matched set only', async () => {
+    const r = await resolveFiles({
+      patterns: ['src/**/*.ts', '!src/sub/**'],
+      root: TEST_DIR,
+      respectGitignore: false,
+      includeUnopened: true,
+      maxFiles: 100,
+    });
+    const rel = r.files.map((f) => f.replace(TEST_DIR, '')).sort();
+    expect(rel).toEqual([join('/src', 'a.ts'), join('/src', 'b.ts')]);
+  });
+
+  it('keeps explicit `paths` entries even when `patterns` negation would remove them', async () => {
+    const explicit = join(TEST_DIR, 'src/sub/d.ts');
+    const r = await resolveFiles({
+      paths: [explicit],
+      patterns: ['src/**/*.ts', '!src/sub/**'],
+      root: TEST_DIR,
+      respectGitignore: false,
+      includeUnopened: true,
+      maxFiles: 100,
+    });
+    expect(r.files).toContain(explicit);
+  });
+
+  it('respects gitignore when enabled', async () => {
+    const r = await resolveFiles({
+      patterns: ['**/*.js'],
+      root: TEST_DIR,
+      respectGitignore: true,
+      includeUnopened: true,
+      maxFiles: 100,
+    });
+    const rel = r.files.map((f) => f.replace(TEST_DIR, ''));
+    // `dist/out.js` filtered by .gitignore, `node_modules/lib.js` by defaults.
+    expect(rel).toEqual([join('/src', 'c.js')]);
+    expect(r.droppedCounts.gitignored).toBeGreaterThan(0);
+  });
+
+  it('disables gitignore filtering when respectGitignore=false', async () => {
+    const r = await resolveFiles({
+      patterns: ['**/*.js'],
+      root: TEST_DIR,
+      respectGitignore: false,
+      includeUnopened: true,
+      maxFiles: 100,
+    });
+    const rel = r.files.map((f) => f.replace(TEST_DIR, '')).sort();
+    expect(rel).toContain(join('/dist', 'out.js'));
+    expect(rel).toContain(join('/src', 'c.js'));
+  });
+
+  it('rejects patterns that escape the root', async () => {
+    const r = await resolveFiles({
+      patterns: ['../../etc/**'],
+      root: TEST_DIR,
+      respectGitignore: false,
+      includeUnopened: true,
+      maxFiles: 100,
+    });
+    expect(r.files).toEqual([]);
+    expect(r.droppedCounts.escaped).toBeGreaterThan(0);
+  });
+
+  it('enforces maxFiles cap and reports the drop count', async () => {
+    const r = await resolveFiles({
+      patterns: ['**/*.ts'],
+      root: TEST_DIR,
+      respectGitignore: false,
+      includeUnopened: true,
+      maxFiles: 2,
+    });
+    expect(r.files.length).toBe(2);
+    expect(r.droppedCounts.maxFiles).toBeGreaterThan(0);
+  });
+
+  it('returns absolute paths sorted alphabetically for determinism', async () => {
+    const r = await resolveFiles({
+      patterns: ['src/**/*.ts'],
+      root: TEST_DIR,
+      respectGitignore: false,
+      includeUnopened: true,
+      maxFiles: 100,
+    });
+    const sortedCopy = [...r.files].sort();
+    expect(r.files).toEqual(sortedCopy);
+  });
+
+  it('returns explicit paths in the union', async () => {
+    const explicit1 = join(TEST_DIR, 'README.md');
+    const explicit2 = join(TEST_DIR, 'src/a.ts');
+    const r = await resolveFiles({
+      paths: [explicit1, explicit2],
+      root: TEST_DIR,
+      respectGitignore: false,
+      includeUnopened: true,
+      maxFiles: 100,
+    });
+    expect(r.files).toContain(explicit1);
+    expect(r.files).toContain(explicit2);
+  });
+
+  it('returns empty list when neither paths nor patterns supplied', async () => {
+    const r = await resolveFiles({
+      root: TEST_DIR,
+      respectGitignore: false,
+      includeUnopened: true,
+      maxFiles: 100,
+    });
+    expect(r.files).toEqual([]);
+  });
+
+  it('throws when root is relative', async () => {
+    await expect(
+      resolveFiles({
+        patterns: ['**/*.ts'],
+        root: 'relative/path',
+        respectGitignore: false,
+        includeUnopened: true,
+        maxFiles: 100,
+      })
+    ).rejects.toThrow(/root must be absolute/);
+  });
+
+  it('walks subdirectories up to the depth cap (no infinite recursion)', async () => {
+    // Create a deeper tree (10 levels) and ensure we still find the leaf.
+    let leaf = join(TEST_DIR, 'deep');
+    await mkdir(leaf, { recursive: true });
+    for (let i = 0; i < 6; i++) {
+      leaf = join(leaf, `lvl${i}`);
+      await mkdir(leaf, { recursive: true });
+    }
+    await writeFile(join(leaf, 'leaf.ts'), 'leaf');
+
+    const r = await resolveFiles({
+      patterns: ['**/leaf.ts'],
+      root: TEST_DIR,
+      respectGitignore: false,
+      includeUnopened: true,
+      maxFiles: 100,
+    });
+    expect(r.files).toContain(join(leaf, 'leaf.ts'));
+  });
+});

--- a/src/file-glob.test.ts
+++ b/src/file-glob.test.ts
@@ -93,10 +93,10 @@ describe('resolveFiles', () => {
     const rel = r.files.map((f) => f.replace(TEST_DIR, ''));
     // `dist/out.js` filtered by .gitignore, `node_modules/lib.js` by defaults.
     expect(rel).toEqual([join('/src', 'c.js')]);
-    expect(r.droppedCounts.gitignored).toBeGreaterThan(0);
+    expect(r.droppedCounts.gitignored).toBe(0);
   });
 
-  it('disables gitignore filtering when respectGitignore=false', async () => {
+  it('still skips always-ignored directories when respectGitignore=false', async () => {
     const r = await resolveFiles({
       patterns: ['**/*.js'],
       root: TEST_DIR,
@@ -105,7 +105,8 @@ describe('resolveFiles', () => {
       maxFiles: 100,
     });
     const rel = r.files.map((f) => f.replace(TEST_DIR, '')).sort();
-    expect(rel).toContain(join('/dist', 'out.js'));
+    expect(rel).not.toContain(join('/dist', 'out.js'));
+    expect(rel).not.toContain(join('/node_modules', 'lib.js'));
     expect(rel).toContain(join('/src', 'c.js'));
   });
 
@@ -119,6 +120,18 @@ describe('resolveFiles', () => {
     });
     expect(r.files).toEqual([]);
     expect(r.droppedCounts.escaped).toBeGreaterThan(0);
+  });
+
+  it('rejects explicit paths that escape the root', async () => {
+    const r = await resolveFiles({
+      paths: ['../../etc/passwd', '/etc/passwd'],
+      root: TEST_DIR,
+      respectGitignore: false,
+      includeUnopened: true,
+      maxFiles: 100,
+    });
+    expect(r.files).toEqual([]);
+    expect(r.droppedCounts.escaped).toBe(2);
   });
 
   it('enforces maxFiles cap and reports the drop count', async () => {

--- a/src/file-glob.ts
+++ b/src/file-glob.ts
@@ -1,5 +1,5 @@
 import { readdir, stat } from 'node:fs/promises';
-import { isAbsolute, join, normalize, relative, resolve, sep } from 'node:path';
+import { basename, isAbsolute, join, normalize, relative, resolve, sep } from 'node:path';
 import picomatch from 'picomatch';
 import { loadGitignore } from './file-scanner.js';
 import { logger } from './logger.js';
@@ -47,6 +47,7 @@ export interface ResolveFilesResult {
 }
 
 const MAX_WALK_DEPTH = 20;
+const ALWAYS_IGNORED_DIRS = new Set(['node_modules', '.git', 'dist', 'build']);
 
 /**
  * Resolve a final list of absolute file paths from explicit `paths` and
@@ -86,6 +87,10 @@ export async function resolveFiles(opts: ResolveFilesOptions): Promise<ResolveFi
   if (opts.paths && opts.paths.length > 0) {
     for (const p of opts.paths) {
       const abs = isAbsolute(p) ? normalize(p) : normalize(resolve(root, p));
+      if (pathEscapesRoot(root, abs)) {
+        dropped.escaped++;
+        continue;
+      }
       finalSet.add(abs);
     }
   }
@@ -120,7 +125,7 @@ export async function resolveFiles(opts: ResolveFilesOptions): Promise<ResolveFi
       const ig = opts.respectGitignore ? await loadGitignore(root) : null;
 
       const candidates: string[] = [];
-      await walkDirectory(root, root, MAX_WALK_DEPTH, async (relPath, absPath) => {
+      await walkDirectory(root, root, MAX_WALK_DEPTH, ig, async (relPath, absPath) => {
         const normalizedRel = relPath.split(sep).join('/');
         if (ig?.ignores(normalizedRel)) {
           dropped.gitignored++;
@@ -164,6 +169,7 @@ async function walkDirectory(
   rootDir: string,
   dir: string,
   maxDepth: number,
+  ig: Awaited<ReturnType<typeof loadGitignore>> | null,
   visit: (relPath: string, absPath: string) => Promise<void>,
   currentDepth = 0
 ): Promise<void> {
@@ -188,7 +194,11 @@ async function walkDirectory(
 
     const rel = relative(rootDir, abs);
     if (st.isDirectory()) {
-      await walkDirectory(rootDir, abs, maxDepth, visit, currentDepth + 1);
+      const normalizedRel = rel.split(sep).join('/');
+      if (ALWAYS_IGNORED_DIRS.has(basename(abs)) || ig?.ignores(normalizedRel)) {
+        continue;
+      }
+      await walkDirectory(rootDir, abs, maxDepth, ig, visit, currentDepth + 1);
     } else if (st.isFile()) {
       await visit(rel, abs);
     }
@@ -213,4 +223,9 @@ function escapesRoot(root: string, pattern: string): boolean {
   // Relative: any `..` segment is suspicious.
   const segments = pattern.split(/[\\/]/);
   return segments.some((s) => s === '..');
+}
+
+function pathEscapesRoot(root: string, absPath: string): boolean {
+  const rel = relative(root, absPath);
+  return rel.startsWith('..') || isAbsolute(rel);
 }

--- a/src/file-glob.ts
+++ b/src/file-glob.ts
@@ -1,0 +1,216 @@
+import { readdir, stat } from 'node:fs/promises';
+import { isAbsolute, join, normalize, relative, resolve, sep } from 'node:path';
+import picomatch from 'picomatch';
+import { loadGitignore } from './file-scanner.js';
+import { logger } from './logger.js';
+
+/**
+ * Options controlling {@link resolveFiles}.
+ */
+export interface ResolveFilesOptions {
+  /**
+   * Explicit list of file paths (absolute or relative to `root`). Survive
+   * negation entries in `patterns` (locked-in decision 10 in the plan).
+   */
+  paths?: string[];
+  /**
+   * Glob patterns evaluated relative to `root`. Negation entries prefixed
+   * with `!` are subtracted from the pattern-resolved set only.
+   */
+  patterns?: string[];
+  /** Root directory for resolution and walking. Must be absolute. */
+  root: string;
+  /** Skip files matched by `.gitignore` + default ignore patterns. */
+  respectGitignore: boolean;
+  /**
+   * Reserved for callers; not consumed by resolveFiles itself. The tool
+   * layer uses it to decide whether to filter to currently-open files.
+   */
+  includeUnopened: boolean;
+  /** Hard cap on the number of files returned. */
+  maxFiles: number;
+}
+
+/**
+ * Result shape of {@link resolveFiles}. `droppedCounts` lets the caller
+ * surface why specific files were excluded.
+ */
+export interface ResolveFilesResult {
+  files: string[];
+  droppedCounts: {
+    gitignored: number;
+    notMatched: number;
+    escaped: number;
+    unreadable: number;
+    maxFiles: number;
+  };
+}
+
+const MAX_WALK_DEPTH = 20;
+
+/**
+ * Resolve a final list of absolute file paths from explicit `paths` and
+ * glob `patterns`, walking from `root`. Pure file-system + matching; no
+ * LSP interaction.
+ *
+ * Behavior:
+ *  - `paths` entries are taken verbatim (no gitignore filter, no
+ *    pattern-negation removal). Relative entries resolve against `root`.
+ *  - `patterns` entries are matched with picomatch. `!`-prefixed entries
+ *    subtract from the matched set.
+ *  - When both are supplied, the final set = union(paths, patterns-result).
+ *  - When neither is supplied, returns an empty `files` list (the tool
+ *    layer treats that as workspace scope and delegates to
+ *    `workspace/diagnostic`).
+ *  - Patterns that resolve to paths *outside* `root` (after
+ *    normalization) are counted under `droppedCounts.escaped`.
+ *  - Returns absolute paths sorted alphabetically for determinism.
+ */
+export async function resolveFiles(opts: ResolveFilesOptions): Promise<ResolveFilesResult> {
+  const root = normalize(opts.root);
+  if (!isAbsolute(root)) {
+    throw new Error(`resolveFiles: root must be absolute (got: ${opts.root})`);
+  }
+
+  const dropped = {
+    gitignored: 0,
+    notMatched: 0,
+    escaped: 0,
+    unreadable: 0,
+    maxFiles: 0,
+  };
+
+  const finalSet = new Set<string>();
+
+  // 1. Explicit `paths`: resolved against root, no gitignore filter.
+  if (opts.paths && opts.paths.length > 0) {
+    for (const p of opts.paths) {
+      const abs = isAbsolute(p) ? normalize(p) : normalize(resolve(root, p));
+      finalSet.add(abs);
+    }
+  }
+
+  // 2. `patterns`: split into positive and negative entries.
+  const patternsList = opts.patterns ?? [];
+  const hasPatterns = patternsList.length > 0;
+  if (hasPatterns) {
+    const positive: string[] = [];
+    const negative: string[] = [];
+    for (const p of patternsList) {
+      if (p.startsWith('!')) negative.push(p.slice(1));
+      else positive.push(p);
+    }
+
+    // Reject patterns that escape `root` after normalization. We don't
+    // attempt to walk above `root`; any pattern whose effective base
+    // resolves outside `root` is counted under `escaped` and skipped.
+    const safePositive: string[] = [];
+    for (const pat of positive) {
+      if (escapesRoot(root, pat)) {
+        dropped.escaped++;
+        continue;
+      }
+      safePositive.push(pat);
+    }
+
+    if (safePositive.length > 0) {
+      const positiveMatcher = picomatch(safePositive, { dot: false, nocase: false });
+      const negativeMatcher = negative.length > 0 ? picomatch(negative, { dot: false }) : null;
+
+      const ig = opts.respectGitignore ? await loadGitignore(root) : null;
+
+      const candidates: string[] = [];
+      await walkDirectory(root, root, MAX_WALK_DEPTH, async (relPath, absPath) => {
+        const normalizedRel = relPath.split(sep).join('/');
+        if (ig?.ignores(normalizedRel)) {
+          dropped.gitignored++;
+          return;
+        }
+        candidates.push(absPath);
+      });
+
+      for (const abs of candidates) {
+        const rel = relative(root, abs).split(sep).join('/');
+        if (!positiveMatcher(rel)) {
+          dropped.notMatched++;
+          continue;
+        }
+        if (negativeMatcher?.(rel)) {
+          // Negation removes from the pattern-resolved set only.
+          dropped.notMatched++;
+          continue;
+        }
+        finalSet.add(abs);
+      }
+    }
+  }
+
+  // 3. Apply max-files cap. Sort deterministically before capping.
+  const sorted = Array.from(finalSet).sort();
+  if (sorted.length > opts.maxFiles) {
+    dropped.maxFiles = sorted.length - opts.maxFiles;
+    sorted.length = opts.maxFiles;
+  }
+
+  return { files: sorted, droppedCounts: dropped };
+}
+
+/**
+ * Walk `dir` up to `maxDepth` levels deep, calling `visit` for every file
+ * encountered. Errors reading directories are logged and silently skipped
+ * so a single unreadable subdirectory cannot kill the whole walk.
+ */
+async function walkDirectory(
+  rootDir: string,
+  dir: string,
+  maxDepth: number,
+  visit: (relPath: string, absPath: string) => Promise<void>,
+  currentDepth = 0
+): Promise<void> {
+  if (currentDepth > maxDepth) return;
+  let entries: string[];
+  try {
+    entries = await readdir(dir);
+  } catch (err) {
+    logger.debug(`[DEBUG resolveFiles] readdir failed for ${dir}: ${err}\n`);
+    return;
+  }
+
+  for (const entry of entries) {
+    const abs = join(dir, entry);
+    let st: Awaited<ReturnType<typeof stat>>;
+    try {
+      st = await stat(abs);
+    } catch (err) {
+      logger.debug(`[DEBUG resolveFiles] stat failed for ${abs}: ${err}\n`);
+      continue;
+    }
+
+    const rel = relative(rootDir, abs);
+    if (st.isDirectory()) {
+      await walkDirectory(rootDir, abs, maxDepth, visit, currentDepth + 1);
+    } else if (st.isFile()) {
+      await visit(rel, abs);
+    }
+  }
+}
+
+/**
+ * Returns true when `pattern` (relative or absolute) clearly resolves
+ * outside `root` after normalization. We use a conservative check: any
+ * pattern containing `..` segments or starting with an absolute path that
+ * is not a child of `root` is rejected. picomatch itself doesn't enforce
+ * sandboxing, so this guard prevents `../../etc/**` from being treated
+ * as legitimate.
+ */
+function escapesRoot(root: string, pattern: string): boolean {
+  if (pattern.startsWith('/') || /^[a-zA-Z]:[\\/]/.test(pattern)) {
+    // Absolute path: must be inside root.
+    const normalized = normalize(pattern);
+    const rel = relative(root, normalized);
+    return rel.startsWith('..') || isAbsolute(rel);
+  }
+  // Relative: any `..` segment is suspicious.
+  const segments = pattern.split(/[\\/]/);
+  return segments.some((s) => s === '..');
+}

--- a/src/get-diagnostics.tool-rendering.test.ts
+++ b/src/get-diagnostics.tool-rendering.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, jest } from 'bun:test';
+import type { LSPClient } from './lsp-client.js';
+import { getDiagnosticsTool } from './tools/diagnostics.js';
+import type { Diagnostic } from './types.js';
+
+/**
+ * Tool-renderer regression for the single-file `get_diagnostics` MCP tool.
+ *
+ * This file pins the exact rendered text produced by `getDiagnosticsTool` for
+ * a realistic mix of diagnostic shapes (error/warning/information/hint, with
+ * and without `code`/`source`). It deliberately mocks `LSPClient.getDiagnostics`
+ * because the unit-under-test is the *tool renderer*, not the underlying LSP
+ * op. The op-path regression lives in `src/lsp/operations.get-diagnostics.test.ts`.
+ *
+ * If PR2/PR3 ever change the rendered text format, this test will fail and the
+ * change must be evaluated explicitly. To regenerate after an *intentional*
+ * format change, replace the EXPECTED_OUTPUT block with the new rendering —
+ * and only when the change is deliberate and reviewed.
+ */
+
+type MockLSPClient = {
+  getDiagnostics: ReturnType<typeof jest.fn>;
+};
+
+function createMockClient(): MockLSPClient {
+  return {
+    getDiagnostics: jest.fn(),
+  };
+}
+
+function callHandler(args: { file_path: string }, mock: MockLSPClient) {
+  return getDiagnosticsTool.handler(args as Record<string, unknown>, mock as unknown as LSPClient);
+}
+
+const SNAPSHOT_DIAGNOSTICS: Diagnostic[] = [
+  {
+    range: {
+      start: { line: 0, character: 0 },
+      end: { line: 0, character: 5 },
+    },
+    severity: 1,
+    message: 'Missing semicolon',
+    code: '1003',
+    source: 'typescript',
+  },
+  {
+    range: {
+      start: { line: 2, character: 10 },
+      end: { line: 2, character: 15 },
+    },
+    severity: 2,
+    message: 'Unused variable',
+    source: 'eslint',
+  },
+  {
+    range: {
+      start: { line: 5, character: 0 },
+      end: { line: 5, character: 20 },
+    },
+    severity: 3,
+    message: 'Consider using const',
+  },
+  {
+    range: {
+      start: { line: 10, character: 4 },
+      end: { line: 10, character: 8 },
+    },
+    severity: 4,
+    message: 'Add type annotation',
+    code: 'no-implicit-any',
+  },
+];
+
+const EXPECTED_OUTPUT = [
+  'Found 4 diagnostics in src/example.ts:',
+  '',
+  '• Error [1003] (typescript): Missing semicolon',
+  '  Location: Line 1, Column 1 to Line 1, Column 6',
+  '',
+  '• Warning (eslint): Unused variable',
+  '  Location: Line 3, Column 11 to Line 3, Column 16',
+  '',
+  '• Information: Consider using const',
+  '  Location: Line 6, Column 1 to Line 6, Column 21',
+  '',
+  '• Hint [no-implicit-any]: Add type annotation',
+  '  Location: Line 11, Column 5 to Line 11, Column 9',
+].join('\n');
+
+describe('get_diagnostics tool renderer (single-file)', () => {
+  let mockClient: MockLSPClient;
+
+  beforeEach(() => {
+    mockClient = createMockClient();
+  });
+
+  it('renders a mixed-severity snapshot byte-for-byte (pins existing format)', async () => {
+    mockClient.getDiagnostics.mockResolvedValue(SNAPSHOT_DIAGNOSTICS);
+
+    const result = await callHandler({ file_path: 'src/example.ts' }, mockClient);
+
+    const text = result.content[0]?.text;
+    expect(text).toBe(EXPECTED_OUTPUT);
+  });
+
+  it('renders the "no diagnostics" message byte-for-byte', async () => {
+    mockClient.getDiagnostics.mockResolvedValue([]);
+
+    const result = await callHandler({ file_path: 'src/clean.ts' }, mockClient);
+
+    expect(result.content[0]?.text).toBe(
+      'No diagnostics found for src/clean.ts. The file has no errors, warnings, or hints.'
+    );
+  });
+
+  it('renders the singular form for exactly one diagnostic', async () => {
+    mockClient.getDiagnostics.mockResolvedValue([
+      {
+        range: {
+          start: { line: 0, character: 5 },
+          end: { line: 0, character: 10 },
+        },
+        severity: 1,
+        message: 'Undefined variable',
+        code: 'TS2304',
+        source: 'typescript',
+      },
+    ]);
+
+    const result = await callHandler({ file_path: 'src/single.ts' }, mockClient);
+
+    expect(result.content[0]?.text).toBe(
+      [
+        'Found 1 diagnostic in src/single.ts:',
+        '',
+        '• Error [TS2304] (typescript): Undefined variable',
+        '  Location: Line 1, Column 6 to Line 1, Column 11',
+      ].join('\n')
+    );
+  });
+
+  it('renders the error path byte-for-byte', async () => {
+    mockClient.getDiagnostics.mockRejectedValue(new Error('LSP server not available'));
+
+    const result = await callHandler({ file_path: 'src/x.ts' }, mockClient);
+
+    expect(result.content[0]?.text).toBe('Error getting diagnostics: LSP server not available');
+  });
+});

--- a/src/lsp-client.batch.test.ts
+++ b/src/lsp-client.batch.test.ts
@@ -123,6 +123,7 @@ describe('LSPClient.getDiagnosticsBatch', () => {
 
     const result = await client.getDiagnosticsBatch({
       paths: [aTs, bPy],
+      root: TEST_DIR,
       timeBudgetMs: 5000,
     });
 
@@ -163,7 +164,7 @@ describe('LSPClient.getDiagnosticsBatch', () => {
 
     spyOn(getServerManager(client), 'getServer').mockResolvedValue(tsState);
 
-    await client.getDiagnosticsBatch({ paths: [aTs], timeBudgetMs: 2000 });
+    await client.getDiagnosticsBatch({ paths: [aTs], root: TEST_DIR, timeBudgetMs: 2000 });
 
     expect(observedDuring).toBe(1);
     // After return, must be back to 0.
@@ -188,13 +189,20 @@ describe('LSPClient.getDiagnosticsBatch', () => {
       return tsState;
     });
 
-    // workspace scope: empty paths/patterns; both buckets get per-file path
-    // (perFilePullBatch on zero files = empty result).
-    const result = await client.getDiagnosticsBatch({ timeBudgetMs: 2000 });
+    // workspace scope: empty paths/patterns; both buckets get per-file fallback
+    // files when workspace/diagnostic is unavailable.
+    const result = await client.getDiagnosticsBatch({ root: TEST_DIR, timeBudgetMs: 2000 });
     expect(result.buckets.length).toBe(2);
-    // No sendRequest because both buckets have 0 files in workspace mode here.
-    expect(tsState.transport.sendRequest).not.toHaveBeenCalled();
-    expect(pyState.transport.sendRequest).not.toHaveBeenCalled();
+    expect(tsState.transport.sendRequest).toHaveBeenCalledWith(
+      'textDocument/diagnostic',
+      { textDocument: { uri: pathToUri(join(TEST_DIR, 'src/a.ts')) } },
+      expect.any(Number)
+    );
+    expect(pyState.transport.sendRequest).toHaveBeenCalledWith(
+      'textDocument/diagnostic',
+      { textDocument: { uri: pathToUri(join(TEST_DIR, 'src/b.py')) } },
+      expect.any(Number)
+    );
 
     client.dispose();
   });
@@ -221,7 +229,7 @@ describe('LSPClient.getDiagnosticsBatch', () => {
       return tsState;
     });
 
-    await client.getDiagnosticsBatch({ timeBudgetMs: 2000 });
+    await client.getDiagnosticsBatch({ root: TEST_DIR, timeBudgetMs: 2000 });
 
     expect(tsState.transport.sendRequest).toHaveBeenCalledWith(
       'workspace/diagnostic',
@@ -247,7 +255,11 @@ describe('LSPClient.getDiagnosticsBatch', () => {
     });
     spyOn(getServerManager(client), 'getServer').mockRejectedValue(new Error('cannot start'));
 
-    const result = await client.getDiagnosticsBatch({ paths: [aTs], timeBudgetMs: 2000 });
+    const result = await client.getDiagnosticsBatch({
+      paths: [aTs],
+      root: TEST_DIR,
+      timeBudgetMs: 2000,
+    });
     expect(result.partial).toBe(true);
     expect(result.partialReasons).toContain('SERVER_CRASH');
     void tsState;
@@ -350,6 +362,7 @@ describe('LSPClient.getDiagnosticsBatch', () => {
 
     const result = await client.getDiagnosticsBatch({
       paths: [aTs, bPy],
+      root: TEST_DIR,
       timeBudgetMs: 150,
     });
 

--- a/src/lsp-client.batch.test.ts
+++ b/src/lsp-client.batch.test.ts
@@ -1,0 +1,362 @@
+import { afterEach, beforeEach, describe, expect, it, jest, spyOn } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdir } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { LSPClient } from './lsp-client.js';
+import type { ServerState } from './lsp/types.js';
+import { pathToUri } from './utils.js';
+
+/** Write a file using Bun.write to avoid node:fs mock interference. */
+async function writeFile(path: string, content: string): Promise<void> {
+  await Bun.write(path, content);
+}
+
+/**
+ * Tests for the LSPClient.getDiagnosticsBatch wiring layer.
+ * Stubs serverManager.getServer to return a synthetic ServerState so we can
+ * verify file→bucket routing, shared deadline propagation, and the
+ * inFlightBatchCount increment/decrement contract.
+ */
+
+/** Access the private `serverManager` field for test spying. */
+function getServerManager(client: LSPClient): {
+  getServer: (cfg: unknown) => Promise<ServerState>;
+} {
+  return (
+    client as unknown as { serverManager: { getServer: (cfg: unknown) => Promise<ServerState> } }
+  ).serverManager;
+}
+
+function makeServerState(opts: {
+  configCommand: string[];
+  capabilities?: ServerState['capabilities'];
+  sendRequest?: (...args: unknown[]) => Promise<unknown>;
+}): ServerState {
+  const inFlightTracker = { current: 0, peak: 0 };
+  const state: ServerState = {
+    process: { kill: jest.fn() } as never,
+    transport: {
+      sendRequest: opts.sendRequest ?? jest.fn().mockResolvedValue({ kind: 'full', items: [] }),
+      sendMessage: jest.fn(),
+      sendNotification: jest.fn(),
+      rejectAllPending: jest.fn(),
+      cancelRequest: jest.fn(),
+      registerProgressHandler: jest.fn(),
+      unregisterProgressHandler: jest.fn(),
+    },
+    documentManager: {
+      ensureOpen: jest.fn().mockResolvedValue(false),
+      ensureOpenAsync: jest.fn().mockResolvedValue(false),
+      closeDocument: jest.fn(),
+      sendChange: jest.fn(),
+      isOpen: jest.fn().mockReturnValue(true),
+      getVersion: jest.fn().mockReturnValue(1),
+    },
+    initialized: true,
+    initializationPromise: Promise.resolve(),
+    startTime: Date.now(),
+    config: { extensions: ['ts'], command: opts.configCommand },
+    diagnosticsCache: {
+      update: jest.fn(),
+      get: jest.fn().mockReturnValue(undefined),
+      waitForIdle: jest.fn().mockResolvedValue(undefined),
+      setResultId: jest.fn(),
+      getResultId: jest.fn().mockReturnValue(undefined),
+    },
+    capabilities: opts.capabilities,
+    inFlightBatchCount: 0,
+  };
+  // Stash counter on the state for inspection.
+  (state as { __tracker?: typeof inFlightTracker }).__tracker = inFlightTracker;
+  return state;
+}
+
+describe('LSPClient.getDiagnosticsBatch', () => {
+  let TEST_DIR: string;
+  let configPath: string;
+
+  beforeEach(async () => {
+    TEST_DIR = mkdtempSync(join(tmpdir(), 'cclsp-lsp-client-batch-'));
+    configPath = join(TEST_DIR, 'cclsp.json');
+    const config = {
+      servers: [
+        {
+          extensions: ['ts', 'tsx'],
+          command: ['typescript-language-server', '--stdio'],
+        },
+        {
+          extensions: ['py'],
+          command: ['pylsp'],
+        },
+      ],
+    };
+    await writeFile(configPath, JSON.stringify(config));
+    await mkdir(join(TEST_DIR, 'src'), { recursive: true });
+    await writeFile(join(TEST_DIR, 'src/a.ts'), 'x');
+    await writeFile(join(TEST_DIR, 'src/b.py'), 'y');
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('buckets files across two server configs and uses a single shared deadline', async () => {
+    const client = new LSPClient(configPath);
+    const aTs = join(TEST_DIR, 'src/a.ts');
+    const bPy = join(TEST_DIR, 'src/b.py');
+
+    const tsState = makeServerState({
+      configCommand: ['typescript-language-server', '--stdio'],
+      capabilities: { diagnosticProvider: true },
+    });
+    const pyState = makeServerState({
+      configCommand: ['pylsp'],
+      capabilities: { diagnosticProvider: true },
+    });
+
+    spyOn(getServerManager(client), 'getServer').mockImplementation(async (cfg: unknown) => {
+      const c = cfg as { command: string[] };
+      if (c.command[0] === 'pylsp') return pyState;
+      return tsState;
+    });
+
+    const result = await client.getDiagnosticsBatch({
+      paths: [aTs, bPy],
+      timeBudgetMs: 5000,
+    });
+
+    expect(result.buckets.length).toBe(2);
+    const bucketKeys = result.buckets.map((b) => b.serverKey).sort();
+    expect(bucketKeys[0]).toContain('pylsp');
+    expect(bucketKeys[1]).toContain('typescript-language-server');
+
+    // Each bucket runs perFilePullBatch (because supportsTextDocumentDiagnostic
+    // is true on the boolean form, but workspaceDiagnostics is false).
+    expect(tsState.transport.sendRequest).toHaveBeenCalledWith(
+      'textDocument/diagnostic',
+      { textDocument: { uri: pathToUri(aTs) } },
+      expect.any(Number)
+    );
+    expect(pyState.transport.sendRequest).toHaveBeenCalledWith(
+      'textDocument/diagnostic',
+      { textDocument: { uri: pathToUri(bPy) } },
+      expect.any(Number)
+    );
+
+    client.dispose();
+  });
+
+  it('increments and decrements inFlightBatchCount via try/finally', async () => {
+    const client = new LSPClient(configPath);
+    const aTs = join(TEST_DIR, 'src/a.ts');
+
+    let observedDuring = -1;
+    const tsState = makeServerState({
+      configCommand: ['typescript-language-server', '--stdio'],
+      capabilities: { diagnosticProvider: true },
+      sendRequest: jest.fn(async () => {
+        observedDuring = tsState.inFlightBatchCount ?? 0;
+        return { kind: 'full', items: [] };
+      }),
+    });
+
+    spyOn(getServerManager(client), 'getServer').mockResolvedValue(tsState);
+
+    await client.getDiagnosticsBatch({ paths: [aTs], timeBudgetMs: 2000 });
+
+    expect(observedDuring).toBe(1);
+    // After return, must be back to 0.
+    expect(tsState.inFlightBatchCount).toBe(0);
+
+    client.dispose();
+  });
+
+  it('falls through to perFilePullBatch when workspaceDiagnostics=false on workspace scope', async () => {
+    const client = new LSPClient(configPath);
+    const tsState = makeServerState({
+      configCommand: ['typescript-language-server', '--stdio'],
+      capabilities: { diagnosticProvider: true },
+    });
+    const pyState = makeServerState({
+      configCommand: ['pylsp'],
+      capabilities: { diagnosticProvider: true },
+    });
+    spyOn(getServerManager(client), 'getServer').mockImplementation(async (cfg: unknown) => {
+      const c = cfg as { command: string[] };
+      if (c.command[0] === 'pylsp') return pyState;
+      return tsState;
+    });
+
+    // workspace scope: empty paths/patterns; both buckets get per-file path
+    // (perFilePullBatch on zero files = empty result).
+    const result = await client.getDiagnosticsBatch({ timeBudgetMs: 2000 });
+    expect(result.buckets.length).toBe(2);
+    // No sendRequest because both buckets have 0 files in workspace mode here.
+    expect(tsState.transport.sendRequest).not.toHaveBeenCalled();
+    expect(pyState.transport.sendRequest).not.toHaveBeenCalled();
+
+    client.dispose();
+  });
+
+  it('uses workspace/diagnostic when server advertises workspaceDiagnostics=true', async () => {
+    const client = new LSPClient(configPath);
+    const tsState = makeServerState({
+      configCommand: ['typescript-language-server', '--stdio'],
+      capabilities: {
+        diagnosticProvider: { interFileDependencies: true, workspaceDiagnostics: true },
+      },
+      sendRequest: jest.fn().mockResolvedValue({ items: [] }),
+    });
+    const pyState = makeServerState({
+      configCommand: ['pylsp'],
+      capabilities: {
+        diagnosticProvider: { interFileDependencies: true, workspaceDiagnostics: true },
+      },
+      sendRequest: jest.fn().mockResolvedValue({ items: [] }),
+    });
+    spyOn(getServerManager(client), 'getServer').mockImplementation(async (cfg: unknown) => {
+      const c = cfg as { command: string[] };
+      if (c.command[0] === 'pylsp') return pyState;
+      return tsState;
+    });
+
+    await client.getDiagnosticsBatch({ timeBudgetMs: 2000 });
+
+    expect(tsState.transport.sendRequest).toHaveBeenCalledWith(
+      'workspace/diagnostic',
+      expect.any(Object),
+      expect.any(Number)
+    );
+    expect(pyState.transport.sendRequest).toHaveBeenCalledWith(
+      'workspace/diagnostic',
+      expect.any(Object),
+      expect.any(Number)
+    );
+
+    client.dispose();
+  });
+
+  it('handles bucket throwing as SERVER_CRASH', async () => {
+    const client = new LSPClient(configPath);
+    const aTs = join(TEST_DIR, 'src/a.ts');
+
+    const tsState = makeServerState({
+      configCommand: ['typescript-language-server', '--stdio'],
+      capabilities: { diagnosticProvider: true },
+    });
+    spyOn(getServerManager(client), 'getServer').mockRejectedValue(new Error('cannot start'));
+
+    const result = await client.getDiagnosticsBatch({ paths: [aTs], timeBudgetMs: 2000 });
+    expect(result.partial).toBe(true);
+    expect(result.partialReasons).toContain('SERVER_CRASH');
+    void tsState;
+    client.dispose();
+  });
+
+  it('skips workspace-scope buckets for servers whose extensions are not in root (S3)', async () => {
+    // Build a separate config with a Go server alongside the TS server. The
+    // tmpdir only contains *.ts/*.py files, so the Go server should NOT
+    // get a bucket on workspace scope.
+    const customConfig = {
+      servers: [
+        {
+          extensions: ['ts', 'tsx'],
+          command: ['typescript-language-server', '--stdio'],
+        },
+        {
+          extensions: ['go'],
+          command: ['gopls'],
+        },
+      ],
+    };
+    const customConfigPath = join(TEST_DIR, 'cclsp-go.json');
+    await writeFile(customConfigPath, JSON.stringify(customConfig));
+
+    const client = new LSPClient(customConfigPath);
+    const tsState = makeServerState({
+      configCommand: ['typescript-language-server', '--stdio'],
+      capabilities: { diagnosticProvider: true },
+    });
+    const goState = makeServerState({
+      configCommand: ['gopls'],
+      capabilities: { diagnosticProvider: true },
+    });
+    spyOn(getServerManager(client), 'getServer').mockImplementation(async (cfg: unknown) => {
+      const c = cfg as { command: string[] };
+      if (c.command[0] === 'gopls') return goState;
+      return tsState;
+    });
+
+    const result = await client.getDiagnosticsBatch({
+      root: TEST_DIR,
+      timeBudgetMs: 2000,
+    });
+
+    const bucketKeys = result.buckets.map((b) => b.serverKey);
+    const hasGo = bucketKeys.some((k) => k.includes('gopls'));
+    expect(hasGo).toBe(false);
+    // Sanity check: the TS bucket exists.
+    expect(bucketKeys.some((k) => k.includes('typescript-language-server'))).toBe(true);
+
+    client.dispose();
+  });
+
+  it('aggregates global BUDGET when one bucket times out and another succeeds (F6)', async () => {
+    const client = new LSPClient(configPath);
+    const aTs = join(TEST_DIR, 'src/a.ts');
+    const bPy = join(TEST_DIR, 'src/b.py');
+
+    // TS bucket succeeds quickly.
+    const tsState = makeServerState({
+      configCommand: ['typescript-language-server', '--stdio'],
+      capabilities: { diagnosticProvider: true },
+      sendRequest: jest.fn().mockResolvedValue({ kind: 'full', items: [] }),
+    });
+
+    // pylsp bucket: sendCancellableRequest returns a never-resolving promise
+    // until the bucket cancels via cancelRequest. This forces a BUDGET drop.
+    const pending: Array<{ id: number; reject: (e: unknown) => void }> = [];
+    let nextId = 200;
+    const pyState = makeServerState({
+      configCommand: ['pylsp'],
+      capabilities: { diagnosticProvider: true },
+    });
+    (pyState.transport as { sendCancellableRequest: unknown }).sendCancellableRequest = jest.fn(
+      () => {
+        const id = nextId++;
+        const promise = new Promise((_r, reject) => {
+          pending.push({ id, reject });
+        });
+        return { id, promise };
+      }
+    );
+    (pyState.transport as { cancelRequest: unknown }).cancelRequest = jest.fn((id: number) => {
+      const e = pending.find((p) => p.id === id);
+      if (e) {
+        // Lazy require to avoid hoisting issues with bun:test.
+        const { RequestCancelledError } = require('./lsp/json-rpc.js') as {
+          RequestCancelledError: new (id: number) => Error;
+        };
+        e.reject(new RequestCancelledError(id));
+      }
+    });
+
+    spyOn(getServerManager(client), 'getServer').mockImplementation(async (cfg: unknown) => {
+      const c = cfg as { command: string[] };
+      if (c.command[0] === 'pylsp') return pyState;
+      return tsState;
+    });
+
+    const result = await client.getDiagnosticsBatch({
+      paths: [aTs, bPy],
+      timeBudgetMs: 150,
+    });
+
+    expect(result.partial).toBe(true);
+    expect(result.partialReasons).toContain('BUDGET');
+    expect(result.partialReasons).not.toContain('SERVER_CRASH');
+
+    client.dispose();
+  });
+});

--- a/src/lsp-client.ts
+++ b/src/lsp-client.ts
@@ -1,7 +1,9 @@
 import { readFileSync } from 'node:fs';
-import { join, normalize, relative } from 'node:path';
+import { join, normalize, relative, resolve } from 'node:path';
+import { resolveFiles } from './file-glob.js';
 import { loadGitignore, scanDirectoryForExtensions } from './file-scanner.js';
 import { logger } from './logger.js';
+import { supportsTextDocumentDiagnostic, supportsWorkspaceDiagnostic } from './lsp/capabilities.js';
 import { loadConfig } from './lsp/config.js';
 import {
   getValidSymbolKinds,
@@ -13,24 +15,34 @@ import {
   hover as opsHover,
   incomingCalls as opsIncomingCalls,
   outgoingCalls as opsOutgoingCalls,
+  perFilePullBatch as opsPerFilePullBatch,
   prepareCallHierarchy as opsPrepareCallHierarchy,
+  pushFallbackBatch as opsPushFallbackBatch,
   renameSymbol as opsRenameSymbol,
+  workspaceDiagnostic as opsWorkspaceDiagnostic,
   workspaceSymbol as opsWorkspaceSymbol,
   symbolKindToString,
 } from './lsp/operations.js';
 import { ServerManager } from './lsp/server-manager.js';
 import type {
+  BatchDiagnosticsRequest,
+  BatchDiagnosticsResult,
   CallHierarchyIncomingCall,
   CallHierarchyItem,
   CallHierarchyOutgoingCall,
   Config,
   Diagnostic,
+  DiagnosticsByFile,
+  DroppedCounts,
   LSPServerConfig,
   Location,
+  PartialReason,
+  PerFileBatchResult,
   Position,
   ServerState,
   SymbolInformation,
   SymbolMatch,
+  WorkspaceDiagnosticOpResult,
 } from './lsp/types.js';
 import type { SymbolKind } from './lsp/types.js';
 import { uriToPath } from './utils.js';
@@ -273,6 +285,320 @@ export class LSPClient {
     return opsGetDiagnostics(serverState, filePath);
   }
 
+  /**
+   * Batch variant of `getDiagnostics`: collects diagnostics across many
+   * files in one call, bucketed by responsible LSP server, with a shared
+   * wall-clock deadline. Used by the `get_workspace_diagnostics` MCP tool.
+   *
+   * - When `paths`/`patterns` are present: resolves the file set via
+   *   `src/file-glob.ts`, buckets by responsible LSPServerConfig, and
+   *   uses per-server `textDocument/diagnostic` or push-fallback paths.
+   * - When both are empty: workspace scope. Each running server with
+   *   `workspaceDiagnostics` capability gets a single
+   *   `workspace/diagnostic` request; otherwise we fall back per-server
+   *   to currently-open files via the per-file pull or push paths.
+   * - `include_unopened=false` forces per-file paths and drops files that
+   *   are not already open in their LSP server.
+   *
+   * Never throws on cap hits — the result's `partial` / `partialReasons`
+   * carry that information so the tool layer can render a header.
+   */
+  async getDiagnosticsBatch(req: BatchDiagnosticsRequest): Promise<BatchDiagnosticsResult> {
+    const rootDir = req.root ? resolve(req.root) : process.cwd();
+    const respectGitignore = req.respectGitignore ?? true;
+    const includeUnopened = req.includeUnopened ?? true;
+    const maxFiles = req.maxFiles ?? 1000;
+    const timeBudgetMs = req.timeBudgetMs ?? 30000;
+
+    const hasPaths = !!req.paths && req.paths.length > 0;
+    const hasPatterns = !!req.patterns && req.patterns.length > 0;
+    const workspaceScope = !hasPaths && !hasPatterns;
+    const scope: BatchDiagnosticsResult['scope'] = workspaceScope
+      ? 'workspace'
+      : hasPaths && hasPatterns
+        ? 'paths+patterns'
+        : hasPaths
+          ? 'paths'
+          : 'patterns';
+
+    const droppedCounts: DroppedCounts = {
+      gitignored: 0,
+      notMatched: 0,
+      escaped: 0,
+      unreadable: 0,
+      maxFiles: 0,
+      budget: 0,
+      noServer: 0,
+      serverCrash: 0,
+      notOpen: 0,
+    };
+
+    const partialReasons = new Set<PartialReason>();
+
+    // 1. Resolve files for non-workspace scope.
+    let files: string[] = [];
+    if (!workspaceScope) {
+      const r = await resolveFiles({
+        paths: req.paths,
+        patterns: req.patterns,
+        root: rootDir,
+        respectGitignore,
+        includeUnopened,
+        maxFiles,
+      });
+      files = r.files;
+      droppedCounts.gitignored += r.droppedCounts.gitignored;
+      droppedCounts.notMatched += r.droppedCounts.notMatched;
+      droppedCounts.escaped += r.droppedCounts.escaped;
+      droppedCounts.unreadable += r.droppedCounts.unreadable;
+      droppedCounts.maxFiles += r.droppedCounts.maxFiles;
+      if (r.droppedCounts.maxFiles > 0) partialReasons.add('MAX_FILES');
+    }
+
+    // 2. Bucket files by responsible server config.
+    interface Bucket {
+      key: string;
+      serverConfig: LSPServerConfig;
+      files: string[];
+      /**
+       * When set, this workspace-scope bucket is forced into per-file
+       * pull mode (because `include_unopened=false` and we enumerated the
+       * server's currently-open files). The pull path will then run
+       * against `files` directly.
+       */
+      forcePerFile?: boolean;
+    }
+    const buckets = new Map<string, Bucket>();
+    const noServerFiles: string[] = [];
+    for (const file of files) {
+      const cfg = this.getServerForFile(file);
+      if (!cfg) {
+        noServerFiles.push(file);
+        continue;
+      }
+      const key = serverKey(cfg);
+      const bucket = buckets.get(key);
+      if (bucket) bucket.files.push(file);
+      else buckets.set(key, { key, serverConfig: cfg, files: [file] });
+    }
+    droppedCounts.noServer = (droppedCounts.noServer ?? 0) + noServerFiles.length;
+
+    // For workspace scope:
+    //   - When `include_unopened=false`, do NOT use workspace pull. Build
+    //     buckets from each running server's currently-open files (via the
+    //     PR1-additive `DocumentManager.listOpen()`), then force per-file
+    //     pull mode in `runBucket`. Configured-but-not-running servers
+    //     contribute nothing because they have no open files.
+    //   - When `include_unopened=true`, work against the union of all
+    //     configured servers — but skip buckets for servers whose
+    //     extensions have no match in a quick scan of `root`, unless the
+    //     server is already running (S3). Caches the scan result.
+    if (workspaceScope) {
+      if (!includeUnopened) {
+        const running = Array.from(this.serverManager.getRunningServers().values());
+        for (const serverState of running) {
+          const openFiles = serverState.documentManager.listOpen?.() ?? [];
+          for (const file of openFiles) {
+            const cfg = this.getServerForFile(file) ?? serverState.config;
+            const key = serverKey(cfg);
+            const bucket = buckets.get(key);
+            if (bucket) {
+              if (!bucket.files.includes(file)) bucket.files.push(file);
+              bucket.forcePerFile = true;
+            } else {
+              buckets.set(key, {
+                key,
+                serverConfig: cfg,
+                files: [file],
+                forcePerFile: true,
+              });
+            }
+          }
+        }
+      } else {
+        const runningKeys = new Set<string>();
+        for (const s of this.serverManager.getRunningServers().values()) {
+          runningKeys.add(serverKey(s.config));
+        }
+        const foundExts = await this.scanRootExtensions(rootDir, respectGitignore);
+        for (const cfg of this.config.servers) {
+          const key = serverKey(cfg);
+          if (buckets.has(key)) continue;
+          const overlap = cfg.extensions.some((ext) => foundExts.has(ext));
+          if (overlap || runningKeys.has(key)) {
+            buckets.set(key, { key, serverConfig: cfg, files: [] });
+          } else {
+            logger.debug(
+              `[getDiagnosticsBatch] Skipping bucket for ${key}: no matching extensions in ${rootDir}\n`
+            );
+          }
+        }
+      }
+    }
+
+    // 3. Single shared deadline.
+    const deadline = Date.now() + timeBudgetMs;
+
+    const items: DiagnosticsByFile[] = [];
+    const bucketSummaries: BatchDiagnosticsResult['buckets'] = [];
+    const partialBucketKeys: string[] = [];
+    const completedBucketKeys: string[] = [];
+
+    // 4. Run buckets in parallel.
+    const bucketPromises: Promise<void>[] = [];
+    for (const bucket of buckets.values()) {
+      bucketPromises.push(
+        this.runBucket({
+          bucket,
+          deadline,
+          workspaceScope,
+          includeUnopened,
+        })
+          .then((result) => {
+            for (const it of result.items) items.push(it);
+            bucketSummaries.push({
+              serverKey: bucket.key,
+              completed: !result.partial,
+              partialReason: result.partialReason,
+              fileCount: bucket.files.length,
+            });
+            if (result.partial) {
+              partialBucketKeys.push(bucket.key);
+              if (result.partialReason) partialReasons.add(result.partialReason);
+            } else {
+              completedBucketKeys.push(bucket.key);
+            }
+            // Merge bucket drops.
+            const dc = result.droppedCounts ?? {};
+            droppedCounts.budget = (droppedCounts.budget ?? 0) + (dc.budget ?? 0);
+            droppedCounts.unreadable += dc.unreadable ?? 0;
+            droppedCounts.serverCrash = (droppedCounts.serverCrash ?? 0) + (dc.serverCrash ?? 0);
+            droppedCounts.notOpen = (droppedCounts.notOpen ?? 0) + (dc.notOpen ?? 0);
+          })
+          .catch((err) => {
+            logger.error(`[getDiagnosticsBatch] Bucket ${bucket.key} threw: ${err}\n`);
+            partialBucketKeys.push(bucket.key);
+            partialReasons.add('SERVER_CRASH');
+            bucketSummaries.push({
+              serverKey: bucket.key,
+              completed: false,
+              partialReason: 'SERVER_CRASH',
+              fileCount: bucket.files.length,
+            });
+            droppedCounts.serverCrash = (droppedCounts.serverCrash ?? 0) + bucket.files.length;
+          })
+      );
+    }
+    await Promise.all(bucketPromises);
+
+    // F6: global BUDGET aggregation. If the shared deadline elapsed but no
+    // bucket flagged BUDGET (e.g., the buckets completed exactly at the
+    // wire), add BUDGET unless a higher-priority reason is already set.
+    if (Date.now() >= deadline) {
+      addReasonRespectingPriority(partialReasons, 'BUDGET');
+    }
+
+    // 5. Dedup defensively by (uri, line, character, code).
+    const seen = new Set<string>();
+    const dedupedItems: DiagnosticsByFile[] = [];
+    for (const file of items) {
+      const kept: Diagnostic[] = [];
+      for (const d of file.items) {
+        const key = `${file.uri}|${d.range.start.line}|${d.range.start.character}|${d.code ?? ''}|${d.message}`;
+        if (seen.has(key)) continue;
+        seen.add(key);
+        kept.push(d);
+      }
+      dedupedItems.push({ uri: file.uri, items: kept });
+    }
+
+    const filesWithDiagnostics = dedupedItems.filter((f) => f.items.length > 0).length;
+    const filesConsidered = workspaceScope ? dedupedItems.length : files.length;
+
+    const partial = partialReasons.size > 0;
+
+    return {
+      items: dedupedItems,
+      buckets: bucketSummaries,
+      filesConsidered,
+      filesWithDiagnostics,
+      scope,
+      rootDir,
+      resolvedRoot: rootDir,
+      partial,
+      partialReasons: Array.from(partialReasons),
+      droppedCounts,
+      completedBucketKeys,
+      partialBucketKeys,
+    };
+  }
+
+  /**
+   * One-shot per call: quick scan of `root` for the set of file extensions
+   * present (depth=2, respecting `.gitignore` when requested). Used by
+   * workspace-scope bucket creation to skip servers whose extensions don't
+   * appear in the tree.
+   */
+  private async scanRootExtensions(
+    rootDir: string,
+    respectGitignore: boolean
+  ): Promise<Set<string>> {
+    try {
+      const ig = respectGitignore ? await loadGitignore(rootDir) : undefined;
+      return await scanDirectoryForExtensions(rootDir, 2, ig, false);
+    } catch (err) {
+      logger.debug(`[getDiagnosticsBatch] scanRootExtensions failed: ${err}\n`);
+      return new Set();
+    }
+  }
+
+  /**
+   * Run a single bucket: pick the strategy (workspace / per-file pull /
+   * push fallback) based on capability and scope, increment/decrement
+   * the in-flight counter, and return the bucket's op result.
+   */
+  private async runBucket(args: {
+    bucket: {
+      key: string;
+      serverConfig: LSPServerConfig;
+      files: string[];
+      forcePerFile?: boolean;
+    };
+    deadline: number;
+    workspaceScope: boolean;
+    includeUnopened: boolean;
+  }): Promise<WorkspaceDiagnosticOpResult | PerFileBatchResult> {
+    const { bucket, deadline, workspaceScope, includeUnopened } = args;
+    const serverState = await this.serverManager.getServer(bucket.serverConfig);
+    serverState.inFlightBatchCount = (serverState.inFlightBatchCount ?? 0) + 1;
+    try {
+      // Workspace-scope happy path: server supports workspace/diagnostic.
+      // Forced per-file (e.g., include_unopened=false) skips this branch.
+      if (
+        workspaceScope &&
+        includeUnopened &&
+        !bucket.forcePerFile &&
+        supportsWorkspaceDiagnostic(serverState)
+      ) {
+        return await opsWorkspaceDiagnostic(serverState, { deadline });
+      }
+
+      const filesForBucket = bucket.files;
+      if (supportsTextDocumentDiagnostic(serverState)) {
+        return await opsPerFilePullBatch(serverState, filesForBucket, {
+          deadline,
+          includeUnopened,
+        });
+      }
+      return await opsPushFallbackBatch(serverState, filesForBucket, {
+        deadline,
+        includeUnopened,
+      });
+    } finally {
+      serverState.inFlightBatchCount = Math.max(0, (serverState.inFlightBatchCount ?? 1) - 1);
+    }
+  }
+
   async hover(
     filePath: string,
     position: Position
@@ -390,4 +716,45 @@ export class LSPClient {
   dispose(): void {
     this.serverManager.dispose();
   }
+}
+
+/**
+ * Stable identity key for a server config used to bucket files in batch
+ * diagnostics. Mirrors locked-in decision 12 in the plan:
+ *   `serverKey = config.command.join(' ') + '@' + (config.rootDir ?? cwd)`.
+ * Ignores irrelevant fields like `restartInterval`.
+ */
+function serverKey(config: LSPServerConfig): string {
+  const root = config.rootDir ?? process.cwd();
+  return `${config.command.join(' ')}@${root}`;
+}
+
+/**
+ * Partial-reason priority used when aggregating across buckets. A higher
+ * index = higher priority. Aggregation only forces BUDGET (or any lower
+ * reason) when no higher-priority reason is already present.
+ *
+ *   SERVER_CRASH > BUDGET > MAX_FILES > MAX_DIAGNOSTICS > MAX_BYTES
+ */
+const PARTIAL_REASON_PRIORITY: PartialReason[] = [
+  'MAX_BYTES',
+  'MAX_DIAGNOSTICS',
+  'MAX_FILES',
+  'BUDGET',
+  'SERVER_CRASH',
+];
+
+/**
+ * Add `reason` to the running set unless a higher-priority reason is
+ * already present. Used by `getDiagnosticsBatch` to surface a global
+ * BUDGET status after `Promise.all` over buckets without overriding a
+ * SERVER_CRASH that happened in any bucket.
+ */
+function addReasonRespectingPriority(set: Set<PartialReason>, reason: PartialReason): void {
+  const incomingRank = PARTIAL_REASON_PRIORITY.indexOf(reason);
+  for (const existing of set) {
+    const r = PARTIAL_REASON_PRIORITY.indexOf(existing);
+    if (r > incomingRank) return; // already have a higher-priority reason
+  }
+  set.add(reason);
 }

--- a/src/lsp-client.ts
+++ b/src/lsp-client.ts
@@ -426,7 +426,21 @@ export class LSPClient {
           if (buckets.has(key)) continue;
           const overlap = cfg.extensions.some((ext) => foundExts.has(ext));
           if (overlap || runningKeys.has(key)) {
-            buckets.set(key, { key, serverConfig: cfg, files: [] });
+            const runningState = Array.from(this.serverManager.getRunningServers().values()).find(
+              (s) => serverKey(s.config) === key
+            );
+            const openFiles = runningState?.documentManager.listOpen?.() ?? [];
+            const matchingOpenFiles = openFiles.filter((file) =>
+              cfg.extensions.includes(getExtension(file))
+            );
+            const fallbackFiles = overlap
+              ? await this.resolveWorkspaceFilesForServer(cfg, rootDir, respectGitignore, maxFiles)
+              : [];
+            buckets.set(key, {
+              key,
+              serverConfig: cfg,
+              files: dedupeStrings([...matchingOpenFiles, ...fallbackFiles]),
+            });
           } else {
             logger.debug(
               `[getDiagnosticsBatch] Skipping bucket for ${key}: no matching extensions in ${rootDir}\n`
@@ -500,17 +514,20 @@ export class LSPClient {
 
     // 5. Dedup defensively by (uri, line, character, code).
     const seen = new Set<string>();
-    const dedupedItems: DiagnosticsByFile[] = [];
+    const dedupedByUri = new Map<string, Diagnostic[]>();
     for (const file of items) {
-      const kept: Diagnostic[] = [];
+      const kept = dedupedByUri.get(file.uri) ?? [];
       for (const d of file.items) {
         const key = `${file.uri}|${d.range.start.line}|${d.range.start.character}|${d.code ?? ''}|${d.message}`;
         if (seen.has(key)) continue;
         seen.add(key);
         kept.push(d);
       }
-      dedupedItems.push({ uri: file.uri, items: kept });
+      dedupedByUri.set(file.uri, kept);
     }
+    const dedupedItems: DiagnosticsByFile[] = Array.from(dedupedByUri.entries()).map(
+      ([uri, items]) => ({ uri, items })
+    );
 
     const filesWithDiagnostics = dedupedItems.filter((f) => f.items.length > 0).length;
     const filesConsidered = workspaceScope ? dedupedItems.length : files.length;
@@ -535,7 +552,7 @@ export class LSPClient {
 
   /**
    * One-shot per call: quick scan of `root` for the set of file extensions
-   * present (depth=2, respecting `.gitignore` when requested). Used by
+   * present (depth=5, respecting `.gitignore` when requested). Used by
    * workspace-scope bucket creation to skip servers whose extensions don't
    * appear in the tree.
    */
@@ -545,7 +562,7 @@ export class LSPClient {
   ): Promise<Set<string>> {
     try {
       const ig = respectGitignore ? await loadGitignore(rootDir) : undefined;
-      return await scanDirectoryForExtensions(rootDir, 2, ig, false);
+      return await scanDirectoryForExtensions(rootDir, 5, ig, false);
     } catch (err) {
       logger.debug(`[getDiagnosticsBatch] scanRootExtensions failed: ${err}\n`);
       return new Set();
@@ -597,6 +614,23 @@ export class LSPClient {
     } finally {
       serverState.inFlightBatchCount = Math.max(0, (serverState.inFlightBatchCount ?? 1) - 1);
     }
+  }
+
+  private async resolveWorkspaceFilesForServer(
+    cfg: LSPServerConfig,
+    rootDir: string,
+    respectGitignore: boolean,
+    maxFiles: number
+  ): Promise<string[]> {
+    const patterns = cfg.extensions.flatMap((ext) => [`*.${ext}`, `**/*.${ext}`]);
+    const result = await resolveFiles({
+      patterns,
+      root: rootDir,
+      respectGitignore,
+      includeUnopened: true,
+      maxFiles,
+    });
+    return result.files;
   }
 
   async hover(
@@ -727,6 +761,14 @@ export class LSPClient {
 function serverKey(config: LSPServerConfig): string {
   const root = config.rootDir ?? process.cwd();
   return `${config.command.join(' ')}@${root}`;
+}
+
+function getExtension(filePath: string): string {
+  return filePath.split('.').pop() ?? '';
+}
+
+function dedupeStrings(values: string[]): string[] {
+  return Array.from(new Set(values));
 }
 
 /**

--- a/src/lsp/adapters/pyright.ts
+++ b/src/lsp/adapters/pyright.ts
@@ -32,13 +32,16 @@ export class PyrightAdapter implements ServerAdapter {
   }
 
   getTimeout(method: string): number | undefined {
-    // Pyright can be slow on large projects
-    // Extend timeouts for operations that may analyze many files
+    // Pyright can be slow on large projects. The `workspace/diagnostic`
+    // entry is an upper bound used only by the PR2 batch path; the
+    // bucket's shared deadline still clamps the real timeout via
+    // `Math.min(adapterMax, remaining)`.
     const timeouts: Record<string, number> = {
       'textDocument/definition': 45000, // 45 seconds
       'textDocument/references': 60000, // 60 seconds
       'textDocument/rename': 60000, // 60 seconds
       'textDocument/documentSymbol': 45000, // 45 seconds
+      'workspace/diagnostic': 90000, // 90 seconds (PR2 batch upper bound)
     };
     return timeouts[method];
   }

--- a/src/lsp/adapters/vue.ts
+++ b/src/lsp/adapters/vue.ts
@@ -53,12 +53,16 @@ export class VueLanguageServerAdapter implements ServerAdapter {
 
   getTimeout(method: string): number | undefined {
     // Vue language server can be slow on certain operations
-    // that require TypeScript analysis
+    // that require TypeScript analysis. The `workspace/diagnostic` entry
+    // is an upper-bound used only by the PR2 batch path; the bucket's
+    // shared deadline still clamps the real timeout via
+    // `Math.min(adapterMax, remaining)`.
     const timeouts: Record<string, number> = {
       'textDocument/documentSymbol': 60000, // 60 seconds
       'textDocument/definition': 45000, // 45 seconds
       'textDocument/references': 45000, // 45 seconds
       'textDocument/rename': 45000, // 45 seconds
+      'workspace/diagnostic': 60000, // 60 seconds (PR2 batch upper bound)
     };
     return timeouts[method];
   }

--- a/src/lsp/capabilities.test.ts
+++ b/src/lsp/capabilities.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'bun:test';
+import { supportsTextDocumentDiagnostic, supportsWorkspaceDiagnostic } from './capabilities.js';
+import type { ServerCapabilities, ServerState } from './types.js';
+
+/**
+ * Build a minimal ServerState-shaped object for capability tests. Only the
+ * `capabilities` field is consulted by the helpers under test; the rest is
+ * filled with stubs.
+ */
+function makeState(capabilities: ServerCapabilities | undefined): ServerState {
+  return {
+    process: {} as unknown as ServerState['process'],
+    transport: {
+      sendRequest: async () => undefined,
+      sendMessage: () => undefined,
+      sendNotification: () => undefined,
+      rejectAllPending: () => undefined,
+    },
+    documentManager: {
+      ensureOpen: async () => false,
+      sendChange: () => undefined,
+      isOpen: () => false,
+      getVersion: () => 0,
+    },
+    initialized: true,
+    initializationPromise: Promise.resolve(),
+    startTime: 0,
+    config: { extensions: [], command: [] },
+    diagnosticsCache: {
+      update: () => undefined,
+      get: () => undefined,
+      waitForIdle: async () => undefined,
+    },
+    capabilities,
+    inFlightBatchCount: 0,
+  };
+}
+
+describe('supportsTextDocumentDiagnostic', () => {
+  it('returns false when capabilities are undefined', () => {
+    expect(supportsTextDocumentDiagnostic(makeState(undefined))).toBe(false);
+  });
+
+  it('returns false when diagnosticProvider is undefined', () => {
+    expect(supportsTextDocumentDiagnostic(makeState({}))).toBe(false);
+  });
+
+  it('returns true when diagnosticProvider is the boolean true shorthand', () => {
+    expect(supportsTextDocumentDiagnostic(makeState({ diagnosticProvider: true }))).toBe(true);
+  });
+
+  it('returns false when diagnosticProvider is explicitly false', () => {
+    expect(supportsTextDocumentDiagnostic(makeState({ diagnosticProvider: false }))).toBe(false);
+  });
+
+  it('returns true when diagnosticProvider is a DiagnosticOptions object', () => {
+    expect(
+      supportsTextDocumentDiagnostic(
+        makeState({
+          diagnosticProvider: {
+            interFileDependencies: true,
+            workspaceDiagnostics: false,
+          },
+        })
+      )
+    ).toBe(true);
+  });
+});
+
+describe('supportsWorkspaceDiagnostic', () => {
+  it('returns false when capabilities are undefined', () => {
+    expect(supportsWorkspaceDiagnostic(makeState(undefined))).toBe(false);
+  });
+
+  it('returns false when diagnosticProvider is undefined', () => {
+    expect(supportsWorkspaceDiagnostic(makeState({}))).toBe(false);
+  });
+
+  it('returns false when diagnosticProvider is the boolean true shorthand', () => {
+    expect(supportsWorkspaceDiagnostic(makeState({ diagnosticProvider: true }))).toBe(false);
+  });
+
+  it('returns false when diagnosticProvider is false', () => {
+    expect(supportsWorkspaceDiagnostic(makeState({ diagnosticProvider: false }))).toBe(false);
+  });
+
+  it('returns false when workspaceDiagnostics is not set on the object form', () => {
+    expect(
+      supportsWorkspaceDiagnostic(
+        makeState({
+          diagnosticProvider: {
+            interFileDependencies: true,
+            workspaceDiagnostics: false,
+          },
+        })
+      )
+    ).toBe(false);
+  });
+
+  it('returns true only when workspaceDiagnostics === true', () => {
+    expect(
+      supportsWorkspaceDiagnostic(
+        makeState({
+          diagnosticProvider: {
+            interFileDependencies: true,
+            workspaceDiagnostics: true,
+          },
+        })
+      )
+    ).toBe(true);
+  });
+});

--- a/src/lsp/capabilities.ts
+++ b/src/lsp/capabilities.ts
@@ -1,0 +1,28 @@
+import type { ServerState } from './types.js';
+
+/**
+ * Pure capability predicates derived from the `initialize` response.
+ *
+ * These helpers keep callers from reaching into capability internals so the
+ * shape can evolve without rippling through batch/operation code.
+ */
+
+/**
+ * Returns true when the server advertises any form of
+ * `diagnosticProvider` capability — either the boolean `true` shorthand or
+ * the structured `DiagnosticOptions` form. Implies support for
+ * `textDocument/diagnostic` pull requests.
+ */
+export function supportsTextDocumentDiagnostic(state: ServerState): boolean {
+  return !!state.capabilities?.diagnosticProvider;
+}
+
+/**
+ * Returns true only when the server advertises
+ * `diagnosticProvider.workspaceDiagnostics === true` (LSP 3.17). The boolean
+ * `true` shorthand does NOT imply workspace diagnostics support.
+ */
+export function supportsWorkspaceDiagnostic(state: ServerState): boolean {
+  const dp = state.capabilities?.diagnosticProvider;
+  return typeof dp === 'object' && dp !== null && dp.workspaceDiagnostics === true;
+}

--- a/src/lsp/diagnostics.test.ts
+++ b/src/lsp/diagnostics.test.ts
@@ -112,4 +112,30 @@ describe('DiagnosticsCache', () => {
       // Should resolve quickly since no updates are happening
     });
   });
+
+  describe('resultId tracking', () => {
+    it('round-trips resultId per URI and returns undefined for unset URIs', () => {
+      const uriA = 'file:///a.ts';
+      const uriB = 'file:///b.ts';
+
+      // Unset → undefined.
+      expect(cache.getResultId(uriA)).toBeUndefined();
+
+      // Set and read back.
+      cache.setResultId(uriA, 'rid-A-1');
+      expect(cache.getResultId(uriA)).toBe('rid-A-1');
+
+      // Independent per URI.
+      cache.setResultId(uriB, 'rid-B-1');
+      expect(cache.getResultId(uriB)).toBe('rid-B-1');
+      expect(cache.getResultId(uriA)).toBe('rid-A-1');
+
+      // Overwrite on second set.
+      cache.setResultId(uriA, 'rid-A-2');
+      expect(cache.getResultId(uriA)).toBe('rid-A-2');
+
+      // Still undefined for an unrelated URI.
+      expect(cache.getResultId('file:///never-set.ts')).toBeUndefined();
+    });
+  });
 });

--- a/src/lsp/diagnostics.ts
+++ b/src/lsp/diagnostics.ts
@@ -48,6 +48,23 @@ export class DiagnosticsCache {
   }
 
   /**
+   * Returns a snapshot of `(uri, value)` pairs for every URI that has a
+   * cached `resultId`. Used to build the `previousResultIds` array for
+   * `workspace/diagnostic` requests so the server can answer with
+   * `kind: 'unchanged'` reports on subsequent calls.
+   *
+   * Order is undefined. The returned array is a fresh copy — mutating it
+   * does not affect the cache.
+   */
+  listResultIds(): Array<{ uri: string; value: string }> {
+    const out: Array<{ uri: string; value: string }> = [];
+    for (const [uri, value] of this.resultIds) {
+      out.push({ uri, value });
+    }
+    return out;
+  }
+
+  /**
    * Wait for diagnostics to stabilize (no updates for `idleTime` ms).
    * Used as fallback when textDocument/diagnostic is not supported.
    *

--- a/src/lsp/diagnostics.ts
+++ b/src/lsp/diagnostics.ts
@@ -50,6 +50,11 @@ export class DiagnosticsCache {
   /**
    * Wait for diagnostics to stabilize (no updates for `idleTime` ms).
    * Used as fallback when textDocument/diagnostic is not supported.
+   *
+   * Optionally accepts an `AbortSignal`; when aborted (either on entry or
+   * between polling iterations) the method returns immediately so callers
+   * racing against an external deadline can short-circuit cleanly. Existing
+   * call sites that omit `signal` see no behavior change.
    */
   async waitForIdle(
     uri: string,
@@ -57,9 +62,15 @@ export class DiagnosticsCache {
       maxWaitTime?: number;
       idleTime?: number;
       checkInterval?: number;
+      signal?: AbortSignal;
     } = {}
   ): Promise<void> {
-    const { maxWaitTime = 1000, idleTime = 100, checkInterval = 50 } = options;
+    const { maxWaitTime = 1000, idleTime = 100, checkInterval = 50, signal } = options;
+
+    if (signal?.aborted) {
+      logger.debug('[DEBUG waitForDiagnosticsIdle] Signal already aborted; returning early\n');
+      return;
+    }
 
     const startTime = Date.now();
     let lastVersion = this.versions.get(uri) ?? -1;
@@ -70,7 +81,15 @@ export class DiagnosticsCache {
     );
 
     while (Date.now() - startTime < maxWaitTime) {
+      if (signal?.aborted) {
+        logger.debug('[DEBUG waitForDiagnosticsIdle] Aborted mid-wait\n');
+        return;
+      }
       await new Promise((resolve) => setTimeout(resolve, checkInterval));
+      if (signal?.aborted) {
+        logger.debug('[DEBUG waitForDiagnosticsIdle] Aborted after poll tick\n');
+        return;
+      }
 
       const currentVersion = this.versions.get(uri) ?? -1;
       const currentUpdateTime = this.lastUpdate.get(uri) ?? lastUpdateTime;

--- a/src/lsp/diagnostics.ts
+++ b/src/lsp/diagnostics.ts
@@ -10,6 +10,7 @@ export class DiagnosticsCache {
   private diagnostics = new Map<string, Diagnostic[]>();
   private lastUpdate = new Map<string, number>();
   private versions = new Map<string, number>();
+  private resultIds = new Map<string, string>();
 
   /**
    * Update cached diagnostics for a URI (called from publishDiagnostics handler).
@@ -27,6 +28,23 @@ export class DiagnosticsCache {
    */
   get(uri: string): Diagnostic[] | undefined {
     return this.diagnostics.get(uri);
+  }
+
+  /**
+   * Store a server-provided `resultId` for a URI. Used by the batch
+   * `workspace/diagnostic` and `textDocument/diagnostic` paths so that
+   * subsequent calls can populate `previousResultIds` and let the server
+   * answer with `kind: 'unchanged'` reports.
+   */
+  setResultId(uri: string, resultId: string): void {
+    this.resultIds.set(uri, resultId);
+  }
+
+  /**
+   * Retrieve the last known `resultId` for a URI, if any.
+   */
+  getResultId(uri: string): string | undefined {
+    return this.resultIds.get(uri);
   }
 
   /**

--- a/src/lsp/diagnostics.ts
+++ b/src/lsp/diagnostics.ts
@@ -37,7 +37,11 @@ export class DiagnosticsCache {
    * answer with `kind: 'unchanged'` reports.
    */
   setResultId(uri: string, resultId: string): void {
-    this.resultIds.set(uri, resultId);
+    if (resultId) {
+      this.resultIds.set(uri, resultId);
+    } else {
+      this.resultIds.delete(uri);
+    }
   }
 
   /**

--- a/src/lsp/document-manager.close.test.ts
+++ b/src/lsp/document-manager.close.test.ts
@@ -70,6 +70,19 @@ describe('DocumentManager.ensureOpenAsync', () => {
     expect(transport.sendNotification).toHaveBeenCalledTimes(1);
   });
 
+  it('does not send duplicate didOpen when opened during async read', async () => {
+    const filePath = join(TEST_DIR, 'a.ts');
+    await writeFile(filePath, 'export const x = 1;');
+
+    const asyncOpen = manager.ensureOpenAsync(filePath);
+    const syncOpened = await manager.ensureOpen(filePath);
+    const asyncOpened = await asyncOpen;
+
+    expect(syncOpened).toBe(true);
+    expect(asyncOpened).toBe(false);
+    expect(transport.sendNotification).toHaveBeenCalledTimes(1);
+  });
+
   it('throws when the file does not exist', async () => {
     const filePath = join(TEST_DIR, 'nonexistent.ts');
     await expect(manager.ensureOpenAsync(filePath)).rejects.toThrow();

--- a/src/lsp/document-manager.close.test.ts
+++ b/src/lsp/document-manager.close.test.ts
@@ -1,0 +1,147 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToUri } from '../utils.js';
+import { DocumentManager } from './document-manager.js';
+import type { JsonRpcTransport } from './json-rpc.js';
+
+/** Write a file using Bun.write to avoid node:fs mock interference. */
+async function writeFile(path: string, content: string): Promise<void> {
+  await Bun.write(path, content);
+}
+
+let TEST_DIR: string;
+
+function createMockTransport(): JsonRpcTransport & {
+  sendNotification: ReturnType<typeof jest.fn>;
+} {
+  return {
+    sendRequest: jest.fn(),
+    sendMessage: jest.fn(),
+    sendNotification: jest.fn(),
+    rejectAllPending: jest.fn(),
+  } as unknown as JsonRpcTransport & {
+    sendNotification: ReturnType<typeof jest.fn>;
+  };
+}
+
+describe('DocumentManager.ensureOpenAsync', () => {
+  let transport: ReturnType<typeof createMockTransport>;
+  let manager: DocumentManager;
+
+  beforeEach(() => {
+    TEST_DIR = mkdtempSync(join(tmpdir(), 'cclsp-docmgr-close-test-'));
+    transport = createMockTransport();
+    manager = new DocumentManager(transport);
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('opens a file via fs.promises.readFile and sends didOpen', async () => {
+    const filePath = join(TEST_DIR, 'a.ts');
+    await writeFile(filePath, 'export const x = 1;');
+
+    const opened = await manager.ensureOpenAsync(filePath);
+
+    expect(opened).toBe(true);
+    expect(transport.sendNotification).toHaveBeenCalledTimes(1);
+    expect(transport.sendNotification).toHaveBeenCalledWith('textDocument/didOpen', {
+      textDocument: expect.objectContaining({
+        languageId: 'typescript',
+        version: 1,
+        text: 'export const x = 1;',
+      }),
+    });
+    expect(manager.isOpen(filePath)).toBe(true);
+    expect(manager.getVersion(filePath)).toBe(1);
+  });
+
+  it('returns false and does not re-send for an already-open file', async () => {
+    const filePath = join(TEST_DIR, 'a.ts');
+    await writeFile(filePath, 'export const x = 1;');
+
+    await manager.ensureOpenAsync(filePath);
+    const result = await manager.ensureOpenAsync(filePath);
+
+    expect(result).toBe(false);
+    expect(transport.sendNotification).toHaveBeenCalledTimes(1);
+  });
+
+  it('throws when the file does not exist', async () => {
+    const filePath = join(TEST_DIR, 'nonexistent.ts');
+    await expect(manager.ensureOpenAsync(filePath)).rejects.toThrow();
+  });
+});
+
+describe('DocumentManager.closeDocument', () => {
+  let transport: ReturnType<typeof createMockTransport>;
+  let manager: DocumentManager;
+
+  beforeEach(() => {
+    TEST_DIR = mkdtempSync(join(tmpdir(), 'cclsp-docmgr-close-test-'));
+    transport = createMockTransport();
+    manager = new DocumentManager(transport);
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('sends textDocument/didClose and removes the file from open set', async () => {
+    const filePath = join(TEST_DIR, 'a.ts');
+    await writeFile(filePath, 'const a = 1;');
+    await manager.ensureOpenAsync(filePath);
+    expect(manager.isOpen(filePath)).toBe(true);
+
+    manager.closeDocument(filePath);
+
+    const uri = pathToUri(filePath);
+    expect(transport.sendNotification).toHaveBeenCalledWith('textDocument/didClose', {
+      textDocument: { uri },
+    });
+    expect(manager.isOpen(filePath)).toBe(false);
+  });
+
+  it('returns silently when called for a file that is not open', () => {
+    const filePath = join(TEST_DIR, 'never-opened.ts');
+
+    expect(() => manager.closeDocument(filePath)).not.toThrow();
+    // No didClose sent because the file was not tracked as open.
+    const calls = transport.sendNotification.mock.calls.filter(
+      (call) => call[0] === 'textDocument/didClose'
+    );
+    expect(calls.length).toBe(0);
+  });
+
+  it('does NOT clear fileVersions when closing (R3 contract)', async () => {
+    const filePath = join(TEST_DIR, 'a.ts');
+    await writeFile(filePath, 'const a = 1;');
+
+    await manager.ensureOpenAsync(filePath);
+    expect(manager.getVersion(filePath)).toBe(1);
+
+    manager.closeDocument(filePath);
+
+    // Version map remains as a hint for any future reopen path.
+    expect(manager.getVersion(filePath)).toBe(1);
+  });
+
+  it('closeDocument on an already-closed file is idempotent', async () => {
+    const filePath = join(TEST_DIR, 'a.ts');
+    await writeFile(filePath, 'const a = 1;');
+
+    await manager.ensureOpenAsync(filePath);
+    manager.closeDocument(filePath);
+
+    // Second close should be a no-op (no extra didClose).
+    transport.sendNotification.mockClear();
+    manager.closeDocument(filePath);
+    const calls = transport.sendNotification.mock.calls.filter(
+      (call) => call[0] === 'textDocument/didClose'
+    );
+    expect(calls.length).toBe(0);
+  });
+});

--- a/src/lsp/document-manager.ts
+++ b/src/lsp/document-manager.ts
@@ -151,6 +151,18 @@ export class DocumentManager {
   }
 
   /**
+   * Returns a snapshot of currently-open file paths. Order is undefined.
+   *
+   * Used by the workspace-diagnostics batch path when
+   * `include_unopened=false` and no explicit `paths`/`patterns` were given,
+   * so the client can enumerate the union of files already open across
+   * every running server.
+   */
+  listOpen(): string[] {
+    return Array.from(this.openFiles);
+  }
+
+  /**
    * Get the current version number for a file.
    */
   getVersion(filePath: string): number {

--- a/src/lsp/document-manager.ts
+++ b/src/lsp/document-manager.ts
@@ -60,6 +60,10 @@ export class DocumentManager {
 
     try {
       const fileContent = await fsPromises.readFile(filePath, 'utf-8');
+      if (this.openFiles.has(filePath)) {
+        logger.debug(`[DEBUG ensureOpenAsync] File opened during async read: ${filePath}\n`);
+        return false;
+      }
       this.openWithContent(filePath, fileContent);
       return true;
     } catch (error) {

--- a/src/lsp/document-manager.ts
+++ b/src/lsp/document-manager.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'node:fs';
+import { promises as fsPromises, readFileSync } from 'node:fs';
 import { logger } from '../logger.js';
 import { pathToUri } from '../utils.js';
 import type { JsonRpcTransport } from './json-rpc.js';
@@ -20,7 +20,8 @@ export class DocumentManager {
 
   /**
    * Ensure a file is open in the LSP server. If already open, returns false.
-   * If not open, reads the file, sends textDocument/didOpen, and returns true.
+   * If not open, reads the file synchronously, sends textDocument/didOpen, and
+   * returns true.
    */
   async ensureOpen(filePath: string): Promise<boolean> {
     if (this.openFiles.has(filePath)) {
@@ -32,30 +33,96 @@ export class DocumentManager {
 
     try {
       const fileContent = readFileSync(filePath, 'utf-8');
-      const uri = pathToUri(filePath);
-      const languageId = getLanguageId(filePath);
-
-      logger.debug(
-        `[DEBUG ensureOpen] File content length: ${fileContent.length}, languageId: ${languageId}\n`
-      );
-
-      this.transport.sendNotification('textDocument/didOpen', {
-        textDocument: {
-          uri,
-          languageId,
-          version: 1,
-          text: fileContent,
-        },
-      });
-
-      this.openFiles.add(filePath);
-      this.fileVersions.set(filePath, 1);
-      logger.debug(`[DEBUG ensureOpen] File opened successfully: ${filePath}\n`);
+      this.openWithContent(filePath, fileContent);
       return true;
     } catch (error) {
       logger.debug(`[DEBUG ensureOpen] Failed to open file ${filePath}: ${error}\n`);
       throw error;
     }
+  }
+
+  /**
+   * Async variant of {@link ensureOpen} using `fs.promises.readFile` instead of
+   * `readFileSync`. Same return semantics: if the file is already open, returns
+   * false; otherwise reads the file asynchronously, sends `textDocument/didOpen`,
+   * adds it to the open-files set, and returns true.
+   *
+   * Added for batch diagnostics workflows that should not block the event loop
+   * with synchronous reads.
+   */
+  async ensureOpenAsync(filePath: string): Promise<boolean> {
+    if (this.openFiles.has(filePath)) {
+      logger.debug(`[DEBUG ensureOpenAsync] File already open: ${filePath}\n`);
+      return false;
+    }
+
+    logger.debug(`[DEBUG ensureOpenAsync] Opening file: ${filePath}\n`);
+
+    try {
+      const fileContent = await fsPromises.readFile(filePath, 'utf-8');
+      this.openWithContent(filePath, fileContent);
+      return true;
+    } catch (error) {
+      logger.debug(`[DEBUG ensureOpenAsync] Failed to open file ${filePath}: ${error}\n`);
+      throw error;
+    }
+  }
+
+  /**
+   * Shared open path: send `textDocument/didOpen` for `filePath` with the given
+   * file content and record the file as open at version 1. Owns the
+   * `pathToUri` + `getLanguageId` + transport send + `openFiles.add` +
+   * `fileVersions.set` work that used to be duplicated across
+   * `ensureOpen` and `ensureOpenAsync`.
+   */
+  private openWithContent(filePath: string, fileContent: string): void {
+    const uri = pathToUri(filePath);
+    const languageId = getLanguageId(filePath);
+
+    logger.debug(
+      `[DEBUG openWithContent] File content length: ${fileContent.length}, languageId: ${languageId}\n`
+    );
+
+    this.transport.sendNotification('textDocument/didOpen', {
+      textDocument: {
+        uri,
+        languageId,
+        version: 1,
+        text: fileContent,
+      },
+    });
+
+    this.openFiles.add(filePath);
+    this.fileVersions.set(filePath, 1);
+    logger.debug(`[DEBUG openWithContent] File opened successfully: ${filePath}\n`);
+  }
+
+  /**
+   * Close a previously-opened document.
+   *
+   * 1. If the file is not currently tracked as open, returns silently.
+   * 2. Otherwise sends `textDocument/didClose` and removes the file from the
+   *    open set.
+   *
+   * We intentionally do NOT clear `fileVersions` here. The R3 batch-path
+   * contract forbids re-opening a file within the same batch, so the retained
+   * version is currently not consumed. It is preserved for inspection/debugging
+   * and to give future cross-batch reopen paths (not implemented in PR1) a
+   * starting point if they ever need monotonic versions.
+   */
+  closeDocument(filePath: string): void {
+    if (!this.openFiles.has(filePath)) {
+      logger.debug(`[DEBUG closeDocument] File not open: ${filePath}\n`);
+      return;
+    }
+
+    const uri = pathToUri(filePath);
+    this.transport.sendNotification('textDocument/didClose', {
+      textDocument: { uri },
+    });
+
+    this.openFiles.delete(filePath);
+    logger.debug(`[DEBUG closeDocument] File closed: ${filePath}\n`);
   }
 
   /**

--- a/src/lsp/json-rpc.cancel.test.ts
+++ b/src/lsp/json-rpc.cancel.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, jest, spyOn } from 'bun:test';
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { logger } from '../logger.js';
+import { JsonRpcTransport, RequestCancelledError } from './json-rpc.js';
+import type { LSPMessage } from './types.js';
+
+/**
+ * Create a mock ChildProcess with emittable stdout and writable stdin.
+ */
+function createMockProcess() {
+  const stdout = new EventEmitter();
+  const stdinData: string[] = [];
+  const stdin = {
+    write: jest.fn((data: string) => {
+      stdinData.push(data);
+      return true;
+    }),
+  };
+
+  const proc = {
+    stdout,
+    stdin,
+    stderr: new EventEmitter(),
+  } as unknown as ChildProcess;
+
+  return {
+    process: proc,
+    stdout,
+    stdin,
+    stdinData,
+    simulateResponse(message: LSPMessage) {
+      const content = JSON.stringify(message);
+      const frame = `Content-Length: ${Buffer.byteLength(content)}\r\n\r\n${content}`;
+      stdout.emit('data', Buffer.from(frame));
+    },
+  };
+}
+
+/** Extract the parsed JSON payload from a `stdinData[i]` string. */
+function parseFramed(written: string): LSPMessage {
+  const contentStart = written.indexOf('{');
+  return JSON.parse(written.substring(contentStart)) as LSPMessage;
+}
+
+type DebugSpy = ReturnType<typeof spyOn<typeof logger, 'debug'>>;
+
+describe('JsonRpcTransport.cancelRequest', () => {
+  let mock: ReturnType<typeof createMockProcess>;
+  let messageHandler: ReturnType<typeof jest.fn>;
+  let transport: JsonRpcTransport;
+  let debugSpy: DebugSpy | undefined;
+
+  beforeEach(() => {
+    mock = createMockProcess();
+    messageHandler = jest.fn();
+    transport = new JsonRpcTransport(mock.process, messageHandler);
+  });
+
+  afterEach(() => {
+    debugSpy?.mockRestore();
+    debugSpy = undefined;
+  });
+
+  it('sends $/cancelRequest framed notification with the request id', async () => {
+    const promise = transport.sendRequest('textDocument/diagnostic', { uri: 'file:///a.ts' }, 5000);
+    promise.catch(() => {
+      // Rejection is expected due to cancel.
+    });
+
+    const sent = parseFramed(mock.stdinData[0] as string);
+    expect(typeof sent.id).toBe('number');
+    const requestId = sent.id as number;
+
+    transport.cancelRequest(requestId);
+
+    // Second framed message should be the $/cancelRequest notification.
+    expect(mock.stdinData.length).toBe(2);
+    const cancel = parseFramed(mock.stdinData[1] as string);
+    expect(cancel.method).toBe('$/cancelRequest');
+    expect(cancel.params).toEqual({ id: requestId });
+    // Notifications have no `id` field.
+    expect(cancel.id).toBeUndefined();
+
+    // Ensure the pending promise rejects so it doesn't dangle.
+    await expect(promise).rejects.toBeInstanceOf(RequestCancelledError);
+  });
+
+  it('rejects the pending promise immediately with RequestCancelledError', async () => {
+    const promise = transport.sendRequest('textDocument/diagnostic', {}, 5000);
+
+    const sent = parseFramed(mock.stdinData[0] as string);
+    transport.cancelRequest(sent.id as number);
+
+    await expect(promise).rejects.toBeInstanceOf(RequestCancelledError);
+    await expect(promise).rejects.toThrow(/cancelled/);
+  });
+
+  it('drops late server responses for already-cancelled ids', async () => {
+    // Spy on logger.debug so we can prove the drop path actually fired,
+    // not just that nothing threw. Restored in afterEach.
+    debugSpy = spyOn(logger, 'debug').mockImplementation(() => {});
+
+    const promise = transport.sendRequest('textDocument/diagnostic', {}, 5000);
+
+    const sent = parseFramed(mock.stdinData[0] as string);
+    const requestId = sent.id as number;
+
+    transport.cancelRequest(requestId);
+    await expect(promise).rejects.toBeInstanceOf(RequestCancelledError);
+
+    // Simulate a late server response for the cancelled id; should NOT throw.
+    expect(() => {
+      mock.simulateResponse({
+        jsonrpc: '2.0',
+        id: requestId,
+        result: { items: [] },
+      });
+    }).not.toThrow();
+
+    // messageHandler is for notifications/requests — responses go nowhere.
+    expect(messageHandler).not.toHaveBeenCalled();
+
+    // The drop path must have emitted a debug line. Match any of the
+    // synonymous markers the implementation may use.
+    const debugMessages = debugSpy.mock.calls
+      .map((args: unknown[]) => (typeof args[0] === 'string' ? args[0] : ''))
+      .join('\n');
+    expect(debugMessages).toMatch(/late response|dropped|cancelled/i);
+  });
+
+  it('is a no-op (race guard) when called for an unknown id', () => {
+    const initialWrites = mock.stdinData.length;
+    // Should not send any notification and should not throw.
+    expect(() => transport.cancelRequest(9999)).not.toThrow();
+    expect(mock.stdinData.length).toBe(initialWrites);
+  });
+
+  it('is a no-op when the response already settled the promise', async () => {
+    const promise = transport.sendRequest('textDocument/diagnostic', {}, 5000);
+    const sent = parseFramed(mock.stdinData[0] as string);
+    const requestId = sent.id as number;
+
+    // Settle normally.
+    mock.simulateResponse({
+      jsonrpc: '2.0',
+      id: requestId,
+      result: { ok: true },
+    });
+    await promise;
+
+    const before = mock.stdinData.length;
+    transport.cancelRequest(requestId);
+    // No additional $/cancelRequest should be sent.
+    expect(mock.stdinData.length).toBe(before);
+  });
+});
+
+describe('RequestCancelledError', () => {
+  it('exposes the request id in the message and uses the right name', () => {
+    const err = new RequestCancelledError(42);
+    expect(err.name).toBe('RequestCancelledError');
+    expect(err.message).toContain('42');
+    expect(err).toBeInstanceOf(Error);
+  });
+});

--- a/src/lsp/json-rpc.progress.test.ts
+++ b/src/lsp/json-rpc.progress.test.ts
@@ -1,0 +1,156 @@
+import { beforeEach, describe, expect, it, jest } from 'bun:test';
+import type { ChildProcess } from 'node:child_process';
+import { EventEmitter } from 'node:events';
+import { JsonRpcTransport } from './json-rpc.js';
+import type { LSPMessage } from './types.js';
+
+function createMockProcess() {
+  const stdout = new EventEmitter();
+  const stdinData: string[] = [];
+  const stdin = {
+    write: jest.fn((data: string) => {
+      stdinData.push(data);
+      return true;
+    }),
+  };
+
+  const proc = {
+    stdout,
+    stdin,
+    stderr: new EventEmitter(),
+  } as unknown as ChildProcess;
+
+  return {
+    process: proc,
+    stdout,
+    stdin,
+    stdinData,
+    simulateResponse(message: LSPMessage) {
+      const content = JSON.stringify(message);
+      const frame = `Content-Length: ${Buffer.byteLength(content)}\r\n\r\n${content}`;
+      stdout.emit('data', Buffer.from(frame));
+    },
+  };
+}
+
+describe('JsonRpcTransport progress handling', () => {
+  let mock: ReturnType<typeof createMockProcess>;
+  let messageHandler: ReturnType<typeof jest.fn>;
+  let transport: JsonRpcTransport;
+
+  beforeEach(() => {
+    mock = createMockProcess();
+    messageHandler = jest.fn();
+    transport = new JsonRpcTransport(mock.process, messageHandler);
+  });
+
+  it('routes $/progress notifications to the registered handler by token', () => {
+    const handler = jest.fn();
+    transport.registerProgressHandler('token-1', handler);
+
+    mock.simulateResponse({
+      jsonrpc: '2.0',
+      method: '$/progress',
+      params: { token: 'token-1', value: { items: ['a', 'b'] } },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith({ items: ['a', 'b'] });
+    // Progress notifications should NOT bubble to onMessage.
+    expect(messageHandler).not.toHaveBeenCalled();
+  });
+
+  it('drops $/progress notifications with unknown tokens at debug level', () => {
+    // No handler registered for 'mystery'.
+    expect(() => {
+      mock.simulateResponse({
+        jsonrpc: '2.0',
+        method: '$/progress',
+        params: { token: 'mystery', value: 'whatever' },
+      });
+    }).not.toThrow();
+
+    expect(messageHandler).not.toHaveBeenCalled();
+  });
+
+  it('accumulates multiple progress notifications in order', () => {
+    const received: unknown[] = [];
+    transport.registerProgressHandler('batch', (value) => {
+      received.push(value);
+    });
+
+    mock.simulateResponse({
+      jsonrpc: '2.0',
+      method: '$/progress',
+      params: { token: 'batch', value: { items: ['x'] } },
+    });
+    mock.simulateResponse({
+      jsonrpc: '2.0',
+      method: '$/progress',
+      params: { token: 'batch', value: { items: ['y'] } },
+    });
+    mock.simulateResponse({
+      jsonrpc: '2.0',
+      method: '$/progress',
+      params: { token: 'batch', value: { items: ['z'] } },
+    });
+
+    expect(received).toEqual([{ items: ['x'] }, { items: ['y'] }, { items: ['z'] }]);
+  });
+
+  it('supports numeric tokens', () => {
+    const handler = jest.fn();
+    transport.registerProgressHandler(7, handler);
+
+    mock.simulateResponse({
+      jsonrpc: '2.0',
+      method: '$/progress',
+      params: { token: 7, value: 'hello' },
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith('hello');
+  });
+
+  it('unregisterProgressHandler removes the handler', () => {
+    const handler = jest.fn();
+    transport.registerProgressHandler('t', handler);
+    transport.unregisterProgressHandler('t');
+
+    mock.simulateResponse({
+      jsonrpc: '2.0',
+      method: '$/progress',
+      params: { token: 't', value: {} },
+    });
+
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it('replaces the prior handler when re-registered with the same token', () => {
+    const first = jest.fn();
+    const second = jest.fn();
+    transport.registerProgressHandler('t', first);
+    transport.registerProgressHandler('t', second);
+
+    mock.simulateResponse({
+      jsonrpc: '2.0',
+      method: '$/progress',
+      params: { token: 't', value: { items: [] } },
+    });
+
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores $/progress notifications missing a token', () => {
+    expect(() => {
+      mock.simulateResponse({
+        jsonrpc: '2.0',
+        method: '$/progress',
+        params: { value: 'no token' },
+      });
+    }).not.toThrow();
+
+    expect(messageHandler).not.toHaveBeenCalled();
+  });
+});

--- a/src/lsp/json-rpc.test.ts
+++ b/src/lsp/json-rpc.test.ts
@@ -197,6 +197,80 @@ describe('JsonRpcTransport', () => {
     });
   });
 
+  describe('handleIncoming dispatch (id=0 + id+method routing)', () => {
+    // The transport's auto-incrementing id starts at 1, but the response
+    // correlation branch must match by `id !== undefined && !method` so that
+    // an id of 0 still routes to a pending request (regressions of the prior
+    // `if (message.id && ...)` truthiness check). We seed the pending map
+    // directly to control the id under test.
+    it('routes id:0 response to pending request', async () => {
+      const pending = (
+        transport as unknown as {
+          pendingRequests: Map<
+            number,
+            { resolve: (value: unknown) => void; reject: (reason?: unknown) => void }
+          >;
+        }
+      ).pendingRequests;
+
+      const promise = new Promise<unknown>((resolve, reject) => {
+        pending.set(0, { resolve, reject });
+      });
+
+      mock.simulateResponse({
+        jsonrpc: '2.0',
+        id: 0,
+        result: { ok: true },
+      });
+
+      const result = await promise;
+      expect(result).toEqual({ ok: true });
+      // Pending entry consumed.
+      expect(pending.has(0)).toBe(false);
+      // Server-initiated request path NOT taken.
+      expect(messageHandler).not.toHaveBeenCalled();
+    });
+
+    it('treats id+method as server-initiated request, not a response', () => {
+      const pending = (
+        transport as unknown as {
+          pendingRequests: Map<
+            number,
+            { resolve: (value: unknown) => void; reject: (reason?: unknown) => void }
+          >;
+        }
+      ).pendingRequests;
+
+      let resolved = false;
+      let rejected = false;
+      pending.set(42, {
+        resolve: () => {
+          resolved = true;
+        },
+        reject: () => {
+          rejected = true;
+        },
+      });
+
+      // Server-initiated request: has both id and method. Must NOT consume the
+      // pending entry under id=42, must flow to the onMessage handler.
+      mock.simulateResponse({
+        jsonrpc: '2.0',
+        id: 42,
+        method: 'tsserver/request',
+        params: { foo: 'bar' },
+      });
+
+      expect(resolved).toBe(false);
+      expect(rejected).toBe(false);
+      expect(pending.has(42)).toBe(true);
+      expect(messageHandler).toHaveBeenCalledTimes(1);
+      expect(messageHandler).toHaveBeenCalledWith(
+        expect.objectContaining({ id: 42, method: 'tsserver/request' })
+      );
+    });
+  });
+
   describe('rejectAllPending', () => {
     it('rejects all outstanding requests', async () => {
       const p1 = transport.sendRequest('method1', {}, 5000);

--- a/src/lsp/json-rpc.ts
+++ b/src/lsp/json-rpc.ts
@@ -27,6 +27,24 @@ export class RequestCancelledError extends Error {
 }
 
 /**
+ * Error rejected from a pending request when the per-request timer elapses
+ * before the server responds. Preserves the historical message format
+ * `"LSP request timeout: <method> (<ms>ms)"` so legacy callers / tests that
+ * match by substring continue to work. Batch paths inspect the class to
+ * classify the rejection as a budget-driven drop (BUDGET) rather than a
+ * server crash (SERVER_CRASH).
+ */
+export class LSPRequestTimeoutError extends Error {
+  constructor(
+    public readonly method: string,
+    public readonly timeoutMs: number
+  ) {
+    super(`LSP request timeout: ${method} (${timeoutMs}ms)`);
+    this.name = 'LSPRequestTimeoutError';
+  }
+}
+
+/**
  * JSON-RPC 2.0 transport over stdio with Content-Length framing.
  *
  * Handles:
@@ -159,6 +177,24 @@ export class JsonRpcTransport {
    * Returns a promise that resolves with the result or rejects on error/timeout.
    */
   sendRequest(method: string, params: unknown, timeout = 30000): Promise<unknown> {
+    return this.sendCancellableRequest(method, params, timeout).promise;
+  }
+
+  /**
+   * Send a JSON-RPC request and expose the assigned id alongside the
+   * response promise. Batch paths need the id so they can call
+   * {@link cancelRequest} when a shared wall-clock deadline elapses.
+   *
+   * `sendRequest` is implemented in terms of this method; the public
+   * `sendRequest` signature is unchanged. Pass `timeout = Infinity` (or any
+   * very large value) to effectively disable the internal timer and rely
+   * solely on an external deadline race + `cancelRequest` for cancellation.
+   */
+  sendCancellableRequest(
+    method: string,
+    params: unknown,
+    timeout = 30000
+  ): { id: number; promise: Promise<unknown> } {
     const id = this.nextId++;
     const message: LSPMessage = {
       jsonrpc: '2.0',
@@ -167,25 +203,30 @@ export class JsonRpcTransport {
       params,
     };
 
-    return new Promise((resolve, reject) => {
-      const timeoutId = setTimeout(() => {
-        this.pendingRequests.delete(id);
-        reject(new Error(`LSP request timeout: ${method} (${timeout}ms)`));
-      }, timeout);
+    const promise = new Promise<unknown>((resolve, reject) => {
+      let timeoutId: ReturnType<typeof setTimeout> | undefined;
+      if (Number.isFinite(timeout)) {
+        timeoutId = setTimeout(() => {
+          this.pendingRequests.delete(id);
+          reject(new LSPRequestTimeoutError(method, timeout));
+        }, timeout);
+      }
 
       this.pendingRequests.set(id, {
         resolve: (value: unknown) => {
-          clearTimeout(timeoutId);
+          if (timeoutId !== undefined) clearTimeout(timeoutId);
           resolve(value);
         },
         reject: (reason?: unknown) => {
-          clearTimeout(timeoutId);
+          if (timeoutId !== undefined) clearTimeout(timeoutId);
           reject(reason);
         },
       });
 
       this.sendMessage(message);
     });
+
+    return { id, promise };
   }
 
   /**

--- a/src/lsp/json-rpc.ts
+++ b/src/lsp/json-rpc.ts
@@ -9,6 +9,24 @@ import type { LSPMessage } from './types.js';
 export type MessageHandler = (message: LSPMessage) => void;
 
 /**
+ * Handler for `$/progress` notification values, routed by token.
+ */
+export type ProgressHandler = (value: unknown) => void;
+
+/**
+ * Error rejected from a pending request when `cancelRequest` is called locally.
+ * The corresponding `$/cancelRequest` notification is sent to the server, but
+ * the local promise rejects immediately regardless of when (or whether) the
+ * server eventually responds.
+ */
+export class RequestCancelledError extends Error {
+  constructor(id: number) {
+    super(`LSP request cancelled (id=${id})`);
+    this.name = 'RequestCancelledError';
+  }
+}
+
+/**
  * JSON-RPC 2.0 transport over stdio with Content-Length framing.
  *
  * Handles:
@@ -26,6 +44,7 @@ export class JsonRpcTransport {
     { resolve: (value: unknown) => void; reject: (reason?: unknown) => void }
   > = new Map();
   private buffer = '';
+  private progressHandlers: Map<string | number, ProgressHandler> = new Map();
 
   constructor(
     private readonly process: ChildProcess,
@@ -79,17 +98,45 @@ export class JsonRpcTransport {
    */
   private handleIncoming(message: LSPMessage): void {
     // Response correlation: match responses to pending requests
-    if (message.id && this.pendingRequests.has(message.id)) {
-      const request = this.pendingRequests.get(message.id);
-      if (!request) return;
-      const { resolve, reject } = request;
-      this.pendingRequests.delete(message.id);
+    if (message.id !== undefined && !message.method) {
+      if (this.pendingRequests.has(message.id)) {
+        const request = this.pendingRequests.get(message.id);
+        if (!request) return;
+        const { resolve, reject } = request;
+        this.pendingRequests.delete(message.id);
 
-      if (message.error) {
-        reject(new Error(message.error.message || 'LSP Error'));
-      } else {
-        resolve(message.result);
+        if (message.error) {
+          reject(new Error(message.error.message || 'LSP Error'));
+        } else {
+          resolve(message.result);
+        }
+        return;
       }
+
+      // Late response (e.g. after cancelRequest). Drop silently at debug.
+      logger.debug(
+        `[DEBUG handleIncoming] Dropping response for unknown/cancelled request id=${message.id}\n`
+      );
+      return;
+    }
+
+    // Route $/progress notifications to the registered handler, keyed by token.
+    if (message.method === '$/progress') {
+      const params = message.params as { token?: string | number; value?: unknown } | undefined;
+      const token = params?.token;
+      if (token === undefined) {
+        logger.debug('[DEBUG handleIncoming] $/progress notification missing token\n');
+        return;
+      }
+      const handler = this.progressHandlers.get(token);
+      if (!handler) {
+        logger.debug(
+          `[DEBUG handleIncoming] No progress handler registered for token=${String(token)}\n`
+        );
+        return;
+      }
+      handler(params?.value);
+      return;
     }
 
     // Delegate notifications and server-initiated requests to the handler
@@ -162,5 +209,44 @@ export class JsonRpcTransport {
       params,
     };
     this.sendMessage(message);
+  }
+
+  /**
+   * Cancel an in-flight request.
+   *
+   * 1. If the request id is not in `pendingRequests`, this is a race (the
+   *    response already arrived or was dropped) — return silently without
+   *    sending the notification or rejecting any promise.
+   * 2. Otherwise: send `$/cancelRequest` to the server, reject the pending
+   *    promise locally with `RequestCancelledError`, and remove it from the
+   *    pending map. Any later response from the server with this id will be
+   *    dropped at debug log level.
+   */
+  cancelRequest(id: number): void {
+    const request = this.pendingRequests.get(id);
+    if (!request) {
+      // Race guard: response already settled or never tracked. Do not notify.
+      return;
+    }
+
+    this.sendNotification('$/cancelRequest', { id });
+
+    this.pendingRequests.delete(id);
+    request.reject(new RequestCancelledError(id));
+  }
+
+  /**
+   * Register a handler for `$/progress` notifications with the given token.
+   * Replaces any previously registered handler for that token.
+   */
+  registerProgressHandler(token: string | number, handler: ProgressHandler): void {
+    this.progressHandlers.set(token, handler);
+  }
+
+  /**
+   * Unregister the progress handler for the given token, if any.
+   */
+  unregisterProgressHandler(token: string | number): void {
+    this.progressHandlers.delete(token);
   }
 }

--- a/src/lsp/operations.batch.test.ts
+++ b/src/lsp/operations.batch.test.ts
@@ -265,7 +265,7 @@ describe('workspaceDiagnostic op', () => {
     expect(uris).toEqual(['file:///a.ts', 'file:///b.ts']);
   });
 
-  it("treats kind:'unchanged' reports as empty in PR2", async () => {
+  it("kind:'unchanged' returns empty when cache has no entry for the uri (defensive)", async () => {
     const transport = createMockTransport({
       sendRequest: jest.fn().mockResolvedValue({
         items: [
@@ -290,6 +290,57 @@ describe('workspaceDiagnostic op', () => {
     const result = await workspaceDiagnostic(state, { deadline: Date.now() + 5000 });
     expect(result.partial).toBeFalsy();
     expect(result.items).toEqual([{ uri: 'file:///a.ts', items: [] }]);
+  });
+
+  it("kind:'unchanged' returns cached items when present", async () => {
+    // PR3: when the server answers `unchanged` for a URI and the cache
+    // already holds items for it, `mergeReports` substitutes the cached
+    // items. This is the positive side of the contract — without it, the
+    // resultId-reuse optimization is useless because we'd always return [].
+    const cachedUri = 'file:///cached.ts';
+    const cachedItems: Diagnostic[] = [
+      {
+        range: { start: { line: 0, character: 0 }, end: { line: 0, character: 3 } },
+        severity: 1,
+        message: 'pre-cached error',
+        source: 'mock',
+      },
+    ];
+    // Pre-populate the cache as if a prior `full` call had already stored
+    // the items + resultId for this URI.
+    const cacheMap = new Map<string, Diagnostic[]>([[cachedUri, cachedItems]]);
+    const cache = createMockDiagnosticsCache(cacheMap);
+    cache.getResultId = jest.fn().mockReturnValue('rid-cached-1');
+
+    const transport = createMockTransport({
+      sendRequest: jest.fn().mockResolvedValue({
+        items: [
+          {
+            uri: cachedUri,
+            kind: 'unchanged',
+            version: 1,
+            resultId: 'rid-cached-1',
+          },
+        ],
+      }),
+    });
+    const state = buildState({
+      transport,
+      documentManager: createMockDocumentManager(),
+      diagnosticsCache: cache,
+      capabilities: {
+        diagnosticProvider: { interFileDependencies: true, workspaceDiagnostics: true },
+      },
+    });
+
+    const result = await workspaceDiagnostic(state, { deadline: Date.now() + 5000 });
+
+    expect(result.partial).toBeFalsy();
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]?.uri).toBe(cachedUri);
+    expect(result.items[0]?.items).toEqual(cachedItems);
+    // The op consults the cache to resolve `unchanged`.
+    expect(cache.get).toHaveBeenCalledWith(cachedUri);
   });
 
   it('returns BUDGET when deadline is already past', async () => {

--- a/src/lsp/operations.batch.test.ts
+++ b/src/lsp/operations.batch.test.ts
@@ -1,0 +1,650 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToUri } from '../utils.js';
+import { RequestCancelledError } from './json-rpc.js';
+import {
+  BATCH_FILE_CONCURRENCY,
+  perFilePullBatch,
+  pushFallbackBatch,
+  workspaceDiagnostic,
+} from './operations.js';
+import type {
+  Diagnostic,
+  ServerCapabilities,
+  ServerState,
+  WorkspaceDocumentDiagnosticReport,
+} from './types.js';
+
+/**
+ * Tests for the PR2 batch diagnostics ops:
+ *   - workspaceDiagnostic
+ *   - perFilePullBatch
+ *   - pushFallbackBatch
+ *
+ * Drives each op against fully-mocked transport / DocumentManager /
+ * DiagnosticsCache to pin protocol shapes (method names, params) and
+ * concurrency/cancellation semantics.
+ */
+
+interface MockTransport {
+  sendRequest: ReturnType<typeof jest.fn>;
+  sendCancellableRequest: ReturnType<typeof jest.fn>;
+  sendNotification: ReturnType<typeof jest.fn>;
+  sendMessage: ReturnType<typeof jest.fn>;
+  rejectAllPending: ReturnType<typeof jest.fn>;
+  cancelRequest: ReturnType<typeof jest.fn>;
+  registerProgressHandler: ReturnType<typeof jest.fn>;
+  unregisterProgressHandler: ReturnType<typeof jest.fn>;
+}
+
+function createMockTransport(
+  overrides: Partial<MockTransport> = {},
+  progressHandlerRef?: { handler?: (value: unknown) => void; token?: string | number }
+): MockTransport {
+  const sendRequest = overrides.sendRequest ?? jest.fn().mockResolvedValue(undefined);
+  // Default `sendCancellableRequest` mirrors the real transport: it
+  // returns an auto-incrementing id alongside the response promise. Each
+  // call to `sendRequest` corresponds to one id. Tests that want to drive
+  // the cancellation path can override `sendCancellableRequest` directly.
+  let nextId = 1;
+  const sendCancellableRequest =
+    overrides.sendCancellableRequest ??
+    jest.fn((method: string, params: unknown, timeout?: number) => {
+      const id = nextId++;
+      const promise = sendRequest(method, params, timeout);
+      return { id, promise };
+    });
+  return {
+    sendRequest,
+    sendCancellableRequest,
+    sendNotification: overrides.sendNotification ?? jest.fn(),
+    sendMessage: overrides.sendMessage ?? jest.fn(),
+    rejectAllPending: overrides.rejectAllPending ?? jest.fn(),
+    cancelRequest: overrides.cancelRequest ?? jest.fn(),
+    registerProgressHandler:
+      overrides.registerProgressHandler ??
+      jest.fn((token: string | number, handler: (value: unknown) => void) => {
+        if (progressHandlerRef) {
+          progressHandlerRef.handler = handler;
+          progressHandlerRef.token = token;
+        }
+      }),
+    unregisterProgressHandler: overrides.unregisterProgressHandler ?? jest.fn(),
+  };
+}
+
+interface MockDocumentManager {
+  ensureOpen: ReturnType<typeof jest.fn>;
+  ensureOpenAsync: ReturnType<typeof jest.fn>;
+  closeDocument: ReturnType<typeof jest.fn>;
+  sendChange: ReturnType<typeof jest.fn>;
+  isOpen: ReturnType<typeof jest.fn>;
+  getVersion: ReturnType<typeof jest.fn>;
+}
+
+function createMockDocumentManager(opts: { isOpen?: boolean } = {}): MockDocumentManager {
+  const openSet = new Set<string>();
+  const openedTracker: string[] = [];
+  return {
+    ensureOpen: jest.fn(async (p: string) => {
+      const wasOpen = openSet.has(p);
+      openSet.add(p);
+      if (!wasOpen) openedTracker.push(p);
+      return !wasOpen;
+    }),
+    ensureOpenAsync: jest.fn(async (p: string) => {
+      const wasOpen = openSet.has(p);
+      openSet.add(p);
+      if (!wasOpen) openedTracker.push(p);
+      return !wasOpen;
+    }),
+    closeDocument: jest.fn((p: string) => {
+      openSet.delete(p);
+    }),
+    sendChange: jest.fn(),
+    isOpen: jest.fn((p: string) => (opts.isOpen !== undefined ? opts.isOpen : openSet.has(p))),
+    getVersion: jest.fn().mockReturnValue(1),
+  };
+}
+
+interface MockDiagnosticsCache {
+  update: ReturnType<typeof jest.fn>;
+  get: ReturnType<typeof jest.fn>;
+  waitForIdle: ReturnType<typeof jest.fn>;
+  setResultId: ReturnType<typeof jest.fn>;
+  getResultId: ReturnType<typeof jest.fn>;
+}
+
+function createMockDiagnosticsCache(
+  cache: Map<string, Diagnostic[]> = new Map()
+): MockDiagnosticsCache {
+  return {
+    update: jest.fn((uri: string, items: Diagnostic[]) => {
+      cache.set(uri, items);
+    }),
+    get: jest.fn((uri: string) => cache.get(uri)),
+    waitForIdle: jest.fn().mockResolvedValue(undefined),
+    setResultId: jest.fn(),
+    getResultId: jest.fn().mockReturnValue(undefined),
+  };
+}
+
+function buildState(parts: {
+  transport: MockTransport;
+  documentManager: MockDocumentManager;
+  diagnosticsCache: MockDiagnosticsCache;
+  capabilities?: ServerCapabilities;
+}): ServerState {
+  return {
+    process: {} as never,
+    transport: parts.transport,
+    documentManager: parts.documentManager,
+    diagnosticsCache: parts.diagnosticsCache,
+    initialized: true,
+    initializationPromise: Promise.resolve(),
+    startTime: Date.now(),
+    config: {
+      extensions: ['ts'],
+      command: ['mock-lsp'],
+    },
+    capabilities: parts.capabilities,
+    inFlightBatchCount: 0,
+  } as ServerState;
+}
+
+describe('workspaceDiagnostic op', () => {
+  it('sends previousResultIds:[] and a UUID partialResultToken (happy path)', async () => {
+    const transport = createMockTransport({
+      sendRequest: jest.fn().mockResolvedValue({
+        items: [
+          {
+            uri: 'file:///a.ts',
+            kind: 'full',
+            version: 1,
+            items: [
+              {
+                range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+                severity: 1,
+                message: 'oops',
+                source: 'mock',
+              },
+            ],
+          },
+        ],
+      }),
+    });
+    const docManager = createMockDocumentManager();
+    const cache = createMockDiagnosticsCache();
+    const state = buildState({
+      transport,
+      documentManager: docManager,
+      diagnosticsCache: cache,
+      capabilities: {
+        diagnosticProvider: { interFileDependencies: true, workspaceDiagnostics: true },
+      },
+    });
+
+    const deadline = Date.now() + 5000;
+    const result = await workspaceDiagnostic(state, { deadline });
+
+    expect(result.partial).toBeFalsy();
+    expect(result.items).toHaveLength(1);
+    expect(result.items[0]?.uri).toBe('file:///a.ts');
+
+    // Pin the request shape.
+    expect(transport.sendRequest).toHaveBeenCalledTimes(1);
+    const firstCall = transport.sendRequest.mock.calls[0];
+    if (!firstCall) throw new Error('expected one call');
+    const [method, params] = firstCall;
+    expect(method).toBe('workspace/diagnostic');
+    const p = params as { previousResultIds: unknown[]; partialResultToken: string };
+    expect(p.previousResultIds).toEqual([]);
+    expect(typeof p.partialResultToken).toBe('string');
+    expect(p.partialResultToken.length).toBeGreaterThan(0);
+
+    // Progress handler must be registered and unregistered.
+    expect(transport.registerProgressHandler).toHaveBeenCalledTimes(1);
+    expect(transport.unregisterProgressHandler).toHaveBeenCalledTimes(1);
+  });
+
+  it('merges $/progress partials with the final response', async () => {
+    const progressRef: { handler?: (value: unknown) => void; token?: string | number } = {};
+    const partial: WorkspaceDocumentDiagnosticReport[] = [
+      {
+        uri: 'file:///a.ts',
+        kind: 'full',
+        version: 1,
+        items: [
+          {
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+            severity: 1,
+            message: 'partial diag',
+          },
+        ],
+      },
+    ];
+    const final: WorkspaceDocumentDiagnosticReport[] = [
+      {
+        uri: 'file:///b.ts',
+        kind: 'full',
+        version: 1,
+        items: [
+          {
+            range: { start: { line: 1, character: 0 }, end: { line: 1, character: 2 } },
+            severity: 2,
+            message: 'final diag',
+          },
+        ],
+      },
+    ];
+    const transport = createMockTransport(
+      {
+        sendRequest: jest.fn(async () => {
+          // Fire a $/progress notification before resolving.
+          progressRef.handler?.({ items: partial });
+          return { items: final };
+        }),
+      },
+      progressRef
+    );
+    const state = buildState({
+      transport,
+      documentManager: createMockDocumentManager(),
+      diagnosticsCache: createMockDiagnosticsCache(),
+      capabilities: {
+        diagnosticProvider: { interFileDependencies: true, workspaceDiagnostics: true },
+      },
+    });
+
+    const result = await workspaceDiagnostic(state, { deadline: Date.now() + 5000 });
+
+    expect(result.partial).toBeFalsy();
+    const uris = result.items.map((i) => i.uri).sort();
+    expect(uris).toEqual(['file:///a.ts', 'file:///b.ts']);
+  });
+
+  it("treats kind:'unchanged' reports as empty in PR2", async () => {
+    const transport = createMockTransport({
+      sendRequest: jest.fn().mockResolvedValue({
+        items: [
+          {
+            uri: 'file:///a.ts',
+            kind: 'unchanged',
+            version: 1,
+            resultId: 'rid-1',
+          },
+        ],
+      }),
+    });
+    const state = buildState({
+      transport,
+      documentManager: createMockDocumentManager(),
+      diagnosticsCache: createMockDiagnosticsCache(),
+      capabilities: {
+        diagnosticProvider: { interFileDependencies: true, workspaceDiagnostics: true },
+      },
+    });
+
+    const result = await workspaceDiagnostic(state, { deadline: Date.now() + 5000 });
+    expect(result.partial).toBeFalsy();
+    expect(result.items).toEqual([{ uri: 'file:///a.ts', items: [] }]);
+  });
+
+  it('returns BUDGET when deadline is already past', async () => {
+    const transport = createMockTransport();
+    const state = buildState({
+      transport,
+      documentManager: createMockDocumentManager(),
+      diagnosticsCache: createMockDiagnosticsCache(),
+      capabilities: {
+        diagnosticProvider: { interFileDependencies: true, workspaceDiagnostics: true },
+      },
+    });
+
+    const result = await workspaceDiagnostic(state, { deadline: Date.now() - 1000 });
+    expect(result.partial).toBe(true);
+    expect(result.partialReason).toBe('BUDGET');
+    expect(transport.sendRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns BUDGET partial when request rejects with RequestCancelledError', async () => {
+    const transport = createMockTransport({
+      sendRequest: jest.fn().mockRejectedValue(new RequestCancelledError(1)),
+    });
+    const state = buildState({
+      transport,
+      documentManager: createMockDocumentManager(),
+      diagnosticsCache: createMockDiagnosticsCache(),
+      capabilities: {
+        diagnosticProvider: { interFileDependencies: true, workspaceDiagnostics: true },
+      },
+    });
+
+    const result = await workspaceDiagnostic(state, { deadline: Date.now() + 5000 });
+    expect(result.partial).toBe(true);
+    expect(result.partialReason).toBe('BUDGET');
+  });
+
+  it('returns SERVER_CRASH partial when transport throws a generic error', async () => {
+    const transport = createMockTransport({
+      sendRequest: jest.fn().mockRejectedValue(new Error('process exited')),
+    });
+    const state = buildState({
+      transport,
+      documentManager: createMockDocumentManager(),
+      diagnosticsCache: createMockDiagnosticsCache(),
+      capabilities: {
+        diagnosticProvider: { interFileDependencies: true, workspaceDiagnostics: true },
+      },
+    });
+
+    const result = await workspaceDiagnostic(state, { deadline: Date.now() + 5000 });
+    expect(result.partial).toBe(true);
+    expect(result.partialReason).toBe('SERVER_CRASH');
+  });
+});
+
+describe('perFilePullBatch op', () => {
+  let TEST_DIR: string;
+  let f1: string;
+  let f2: string;
+  let f3: string;
+
+  beforeEach(() => {
+    TEST_DIR = mkdtempSync(join(tmpdir(), 'cclsp-ops-batch-'));
+    f1 = join(TEST_DIR, 'a.ts');
+    f2 = join(TEST_DIR, 'b.ts');
+    f3 = join(TEST_DIR, 'c.ts');
+    writeFileSync(f1, 'const x = 1;');
+    writeFileSync(f2, 'const y = 2;');
+    writeFileSync(f3, 'const z = 3;');
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('exposes BATCH_FILE_CONCURRENCY = 2', () => {
+    expect(BATCH_FILE_CONCURRENCY).toBe(2);
+  });
+
+  it('issues textDocument/diagnostic with kind:full and returns per-file items', async () => {
+    const transport = createMockTransport({
+      sendRequest: jest.fn(async (_m, params: unknown) => {
+        const uri = (params as { textDocument: { uri: string } }).textDocument.uri;
+        return {
+          kind: 'full',
+          items: [
+            {
+              range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+              severity: 1,
+              message: `diag for ${uri}`,
+            },
+          ],
+        };
+      }),
+    });
+    const state = buildState({
+      transport,
+      documentManager: createMockDocumentManager({ isOpen: true }),
+      diagnosticsCache: createMockDiagnosticsCache(),
+    });
+
+    const result = await perFilePullBatch(state, [f1, f2], {
+      deadline: Date.now() + 5000,
+      concurrency: 2,
+    });
+
+    expect(result.partial).toBeFalsy();
+    expect(result.items).toHaveLength(2);
+    // Pin request shape on the first call.
+    const calls = transport.sendRequest.mock.calls;
+    expect(calls[0]?.[0]).toBe('textDocument/diagnostic');
+    expect(calls[0]?.[1]).toEqual({ textDocument: { uri: pathToUri(f1) } });
+  });
+
+  it('enforces concurrency=2 (no more than 2 in-flight at once)', async () => {
+    let inFlight = 0;
+    let peak = 0;
+    const transport = createMockTransport({
+      sendRequest: jest.fn(async () => {
+        inFlight++;
+        if (inFlight > peak) peak = inFlight;
+        await new Promise((r) => setTimeout(r, 25));
+        inFlight--;
+        return { kind: 'full', items: [] };
+      }),
+    });
+    const state = buildState({
+      transport,
+      documentManager: createMockDocumentManager({ isOpen: true }),
+      diagnosticsCache: createMockDiagnosticsCache(),
+    });
+
+    await perFilePullBatch(state, [f1, f2, f3], {
+      deadline: Date.now() + 5000,
+      concurrency: 2,
+    });
+
+    expect(peak).toBeLessThanOrEqual(2);
+  });
+
+  it('honors the deadline: $/cancelRequest fires for in-flight ids, bucket marked BUDGET', async () => {
+    // Pin the cancellation path end-to-end:
+    //   - `sendCancellableRequest` returns a real id but a promise that
+    //     NEVER resolves on its own.
+    //   - The bucket's deadline race must fire after ~100ms, calling
+    //     `transport.cancelRequest(id)` BEFORE the bucket settles.
+    //   - The bucket then surfaces `partial=true, partialReason='BUDGET'`,
+    //     and the per-file dropped count is incremented under BUDGET
+    //     (not SERVER_CRASH).
+    let nextId = 100;
+    const issuedIds: number[] = [];
+    const pending: Array<{
+      id: number;
+      reject: (err: unknown) => void;
+    }> = [];
+
+    const sendCancellableRequest = jest.fn(
+      (_method: string, _params: unknown, _timeout?: number) => {
+        const id = nextId++;
+        issuedIds.push(id);
+        const promise = new Promise((_resolve, reject) => {
+          pending.push({ id, reject });
+        });
+        return { id, promise };
+      }
+    );
+    const cancelRequest = jest.fn((id: number) => {
+      // Mirror the real transport: server received the cancel, so the
+      // pending local promise rejects with RequestCancelledError.
+      const entry = pending.find((p) => p.id === id);
+      if (entry) entry.reject(new RequestCancelledError(id));
+    });
+
+    const transport = createMockTransport({
+      sendCancellableRequest,
+      cancelRequest,
+    });
+    const state = buildState({
+      transport,
+      documentManager: createMockDocumentManager({ isOpen: true }),
+      diagnosticsCache: createMockDiagnosticsCache(),
+    });
+
+    // Deadline must exceed MIN_PER_REQ_MS (250) so the worker dispatches
+    // at least one request before the deadline race fires.
+    const deadline = Date.now() + 400;
+    const start = Date.now();
+    const result = await perFilePullBatch(state, [f1, f2, f3], {
+      deadline,
+      concurrency: 2,
+    });
+    const elapsed = Date.now() - start;
+
+    // Settles soon after the deadline (allow generous CI margin).
+    expect(elapsed).toBeLessThan(2000);
+
+    // Bucket reports BUDGET — not SERVER_CRASH.
+    expect(result.partial).toBe(true);
+    expect(result.partialReason).toBe('BUDGET');
+    expect(result.droppedCounts?.budget ?? 0).toBeGreaterThan(0);
+    expect(result.droppedCounts?.serverCrash ?? 0).toBe(0);
+
+    // cancelRequest fired for every in-flight id. With concurrency=2 we
+    // expect at least one cancellation against an issued id.
+    expect(cancelRequest).toHaveBeenCalled();
+    const calledIds = cancelRequest.mock.calls.map((c) => c[0]);
+    for (const cid of calledIds) {
+      expect(issuedIds).toContain(cid);
+    }
+  });
+
+  it('marks SERVER_CRASH when request rejects with a generic error', async () => {
+    const transport = createMockTransport({
+      sendRequest: jest.fn().mockRejectedValue(new Error('boom')),
+    });
+    const state = buildState({
+      transport,
+      documentManager: createMockDocumentManager({ isOpen: true }),
+      diagnosticsCache: createMockDiagnosticsCache(),
+    });
+
+    const result = await perFilePullBatch(state, [f1], { deadline: Date.now() + 5000 });
+    expect(result.partial).toBe(true);
+    expect(result.partialReason).toBe('SERVER_CRASH');
+  });
+
+  it('opens files that are not yet open and closes them after the request (one-shot)', async () => {
+    const docManager = createMockDocumentManager(); // tracks open set
+    const transport = createMockTransport({
+      sendRequest: jest.fn().mockResolvedValue({ kind: 'full', items: [] }),
+    });
+    const state = buildState({
+      transport,
+      documentManager: docManager,
+      diagnosticsCache: createMockDiagnosticsCache(),
+    });
+
+    const result = await perFilePullBatch(state, [f1], { deadline: Date.now() + 5000 });
+    expect(result.partial).toBeFalsy();
+    expect(docManager.ensureOpenAsync).toHaveBeenCalledTimes(1);
+    expect(docManager.closeDocument).toHaveBeenCalledTimes(1);
+  });
+
+  it('drops not-open files when includeUnopened=false and never opens them', async () => {
+    const docManager = createMockDocumentManager({ isOpen: false });
+    const transport = createMockTransport();
+    const state = buildState({
+      transport,
+      documentManager: docManager,
+      diagnosticsCache: createMockDiagnosticsCache(),
+    });
+
+    const result = await perFilePullBatch(state, [f1, f2], {
+      deadline: Date.now() + 5000,
+      includeUnopened: false,
+    });
+
+    expect(docManager.ensureOpenAsync).not.toHaveBeenCalled();
+    expect(transport.sendRequest).not.toHaveBeenCalled();
+    expect(result.droppedCounts?.notOpen).toBe(2);
+  });
+
+  it("treats kind:'unchanged' as empty per file", async () => {
+    const transport = createMockTransport({
+      sendRequest: jest.fn().mockResolvedValue({ kind: 'unchanged', resultId: 'rid-x' }),
+    });
+    const state = buildState({
+      transport,
+      documentManager: createMockDocumentManager({ isOpen: true }),
+      diagnosticsCache: createMockDiagnosticsCache(),
+    });
+    const result = await perFilePullBatch(state, [f1], { deadline: Date.now() + 5000 });
+    expect(result.items[0]?.items).toEqual([]);
+  });
+});
+
+describe('pushFallbackBatch op', () => {
+  let TEST_DIR: string;
+  let f1: string;
+
+  beforeEach(() => {
+    TEST_DIR = mkdtempSync(join(tmpdir(), 'cclsp-ops-batch-push-'));
+    f1 = join(TEST_DIR, 'a.ts');
+    writeFileSync(f1, 'const x = 1;');
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('opens → waitForIdle → reads cache → closes', async () => {
+    const docManager = createMockDocumentManager();
+    const cacheMap = new Map<string, Diagnostic[]>([
+      [
+        pathToUri(f1),
+        [
+          {
+            range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+            severity: 2,
+            message: 'cached',
+          },
+        ],
+      ],
+    ]);
+    const cache = createMockDiagnosticsCache(cacheMap);
+    const state = buildState({
+      transport: createMockTransport(),
+      documentManager: docManager,
+      diagnosticsCache: cache,
+    });
+
+    const result = await pushFallbackBatch(state, [f1], { deadline: Date.now() + 5000 });
+    expect(result.partial).toBeFalsy();
+    expect(docManager.ensureOpenAsync).toHaveBeenCalled();
+    expect(cache.waitForIdle).toHaveBeenCalled();
+    expect(docManager.closeDocument).toHaveBeenCalled();
+    expect(result.items[0]?.items).toHaveLength(1);
+  });
+
+  it('respects openedByMe: leaves already-open files open after batch', async () => {
+    const docManager = createMockDocumentManager({ isOpen: true });
+    const cache = createMockDiagnosticsCache(new Map([[pathToUri(f1), []]]));
+    const state = buildState({
+      transport: createMockTransport(),
+      documentManager: docManager,
+      diagnosticsCache: cache,
+    });
+
+    await pushFallbackBatch(state, [f1], { deadline: Date.now() + 5000 });
+    expect(docManager.ensureOpenAsync).not.toHaveBeenCalled();
+    expect(docManager.closeDocument).not.toHaveBeenCalled();
+  });
+});
+
+describe('capability-based strategy selection (callers should gate ops)', () => {
+  // These tests pin the capability helpers — they live in capabilities.ts —
+  // but verify that workspaceDiagnostic and perFilePullBatch behave correctly
+  // when the caller's gating is wrong (sanity check: ops do not themselves
+  // re-check capabilities and just trust the caller).
+
+  it('workspaceDiagnostic still sends the request even without explicit capabilities (caller gating only)', async () => {
+    const transport = createMockTransport({
+      sendRequest: jest.fn().mockResolvedValue({ items: [] }),
+    });
+    const state = buildState({
+      transport,
+      documentManager: createMockDocumentManager(),
+      diagnosticsCache: createMockDiagnosticsCache(),
+    });
+    await workspaceDiagnostic(state, { deadline: Date.now() + 5000 });
+    expect(transport.sendRequest).toHaveBeenCalledWith(
+      'workspace/diagnostic',
+      expect.any(Object),
+      expect.any(Number)
+    );
+  });
+});

--- a/src/lsp/operations.get-diagnostics.test.ts
+++ b/src/lsp/operations.get-diagnostics.test.ts
@@ -1,0 +1,240 @@
+import { afterEach, beforeEach, describe, expect, it, jest } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToUri } from '../utils.js';
+import { getDiagnostics as opsGetDiagnostics } from './operations.js';
+import type { Diagnostic, ServerState } from './types.js';
+
+/**
+ * Op-level regression for `getDiagnostics(serverState, filePath)` in
+ * `src/lsp/operations.ts`. Drives the op directly against fully-mocked
+ * transport, DocumentManager, and DiagnosticsCache so that any refactor of
+ * the op-path messaging shape (method name, params) gets caught here.
+ *
+ * Covers the three branches:
+ *   1. cached `publishDiagnostics` path.
+ *   2. `textDocument/diagnostic` pull path — `kind: 'full'`.
+ *   3. `textDocument/diagnostic` pull path — `kind: 'unchanged'`.
+ *   4. error fallback path — `sendChange` no-op + `waitForIdle`.
+ */
+
+interface MockTransport {
+  sendRequest: ReturnType<typeof jest.fn>;
+  sendNotification: ReturnType<typeof jest.fn>;
+  sendMessage: ReturnType<typeof jest.fn>;
+  rejectAllPending: ReturnType<typeof jest.fn>;
+}
+
+interface MockDocumentManager {
+  ensureOpen: ReturnType<typeof jest.fn>;
+  sendChange: ReturnType<typeof jest.fn>;
+  isOpen: ReturnType<typeof jest.fn>;
+  getVersion: ReturnType<typeof jest.fn>;
+}
+
+interface MockDiagnosticsCache {
+  update: ReturnType<typeof jest.fn>;
+  get: ReturnType<typeof jest.fn>;
+  waitForIdle: ReturnType<typeof jest.fn>;
+}
+
+function createMockTransport(overrides: Partial<MockTransport> = {}): MockTransport {
+  return {
+    sendRequest: overrides.sendRequest ?? jest.fn().mockResolvedValue(undefined),
+    sendNotification: overrides.sendNotification ?? jest.fn(),
+    sendMessage: overrides.sendMessage ?? jest.fn(),
+    rejectAllPending: overrides.rejectAllPending ?? jest.fn(),
+  };
+}
+
+function createMockDocumentManager(): MockDocumentManager {
+  return {
+    ensureOpen: jest.fn().mockResolvedValue(false),
+    sendChange: jest.fn(),
+    isOpen: jest.fn().mockReturnValue(true),
+    getVersion: jest.fn().mockReturnValue(1),
+  };
+}
+
+function createMockDiagnosticsCache(
+  cache: Map<string, Diagnostic[]> = new Map()
+): MockDiagnosticsCache {
+  return {
+    update: jest.fn((uri: string, items: Diagnostic[]) => {
+      cache.set(uri, items);
+    }),
+    get: jest.fn((uri: string) => cache.get(uri)),
+    waitForIdle: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function buildState(parts: {
+  transport: MockTransport;
+  documentManager: MockDocumentManager;
+  diagnosticsCache: MockDiagnosticsCache;
+}): ServerState {
+  return {
+    process: {} as never,
+    transport: parts.transport,
+    documentManager: parts.documentManager,
+    diagnosticsCache: parts.diagnosticsCache,
+    initialized: true,
+    initializationPromise: Promise.resolve(),
+    startTime: Date.now(),
+    config: {
+      extensions: ['ts'],
+      command: ['mock-lsp'],
+    },
+  } as ServerState;
+}
+
+const DIAGS_A: Diagnostic[] = [
+  {
+    range: { start: { line: 1, character: 2 }, end: { line: 1, character: 5 } },
+    severity: 1,
+    message: 'boom',
+    source: 'mock',
+    code: 'E001',
+  },
+];
+
+const DIAGS_B: Diagnostic[] = [
+  {
+    range: { start: { line: 0, character: 0 }, end: { line: 0, character: 4 } },
+    severity: 2,
+    message: 'pulled via textDocument/diagnostic',
+    source: 'mock',
+  },
+];
+
+describe('opsGetDiagnostics (single-file op)', () => {
+  let TEST_DIR: string;
+  let filePath: string;
+  let fileUri: string;
+
+  beforeEach(() => {
+    TEST_DIR = mkdtempSync(join(tmpdir(), 'cclsp-ops-get-diag-'));
+    filePath = join(TEST_DIR, 'example.ts');
+    writeFileSync(filePath, 'const x = 1;\n', 'utf-8');
+    fileUri = pathToUri(filePath);
+  });
+
+  afterEach(() => {
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('returns cached publishDiagnostics when available (no transport request issued)', async () => {
+    const transport = createMockTransport();
+    const docManager = createMockDocumentManager();
+    const cache = createMockDiagnosticsCache(new Map([[fileUri, DIAGS_A]]));
+    const state = buildState({
+      transport,
+      documentManager: docManager,
+      diagnosticsCache: cache,
+    });
+
+    const result = await opsGetDiagnostics(state, filePath);
+
+    expect(result).toEqual(DIAGS_A);
+    expect(docManager.ensureOpen).toHaveBeenCalledWith(filePath);
+    // Cached path must NOT issue a request.
+    expect(transport.sendRequest).not.toHaveBeenCalled();
+  });
+
+  it('returns items from textDocument/diagnostic when report is kind:full', async () => {
+    const transport = createMockTransport({
+      sendRequest: jest.fn().mockResolvedValue({
+        kind: 'full',
+        items: DIAGS_B,
+      }),
+    });
+    const docManager = createMockDocumentManager();
+    const cache = createMockDiagnosticsCache(); // nothing cached
+    const state = buildState({
+      transport,
+      documentManager: docManager,
+      diagnosticsCache: cache,
+    });
+
+    const result = await opsGetDiagnostics(state, filePath);
+
+    expect(result).toEqual(DIAGS_B);
+    // Pin the exact request shape: method + textDocument.uri.
+    expect(transport.sendRequest).toHaveBeenCalledTimes(1);
+    expect(transport.sendRequest).toHaveBeenCalledWith('textDocument/diagnostic', {
+      textDocument: { uri: fileUri },
+    });
+  });
+
+  it('returns [] when textDocument/diagnostic report is kind:unchanged', async () => {
+    const transport = createMockTransport({
+      sendRequest: jest.fn().mockResolvedValue({
+        kind: 'unchanged',
+        resultId: 'rid-123',
+      }),
+    });
+    const docManager = createMockDocumentManager();
+    const cache = createMockDiagnosticsCache();
+    const state = buildState({
+      transport,
+      documentManager: docManager,
+      diagnosticsCache: cache,
+    });
+
+    const result = await opsGetDiagnostics(state, filePath);
+
+    expect(result).toEqual([]);
+    expect(transport.sendRequest).toHaveBeenCalledTimes(1);
+    expect(transport.sendRequest).toHaveBeenCalledWith('textDocument/diagnostic', {
+      textDocument: { uri: fileUri },
+    });
+  });
+
+  it('falls back to waitForIdle when textDocument/diagnostic throws (cache hit after first idle wait)', async () => {
+    // This pins the simpler half of the error-fallback path: when the pull
+    // request fails, the op first awaits `cache.waitForIdle` and then checks
+    // the cache. If the cache is now populated (i.e. publishDiagnostics
+    // arrived during the wait), the op returns those items WITHOUT entering
+    // the no-op `didChange` re-trigger path. We deliberately exercise this
+    // earlier-exit branch because the re-trigger path additionally calls
+    // `readFileSync` from `node:fs`, which is `mock.module`-replaced by
+    // `setup.test.ts` in this test suite — replicating that here would only
+    // duplicate that fragile module-mock dance.
+    const transport = createMockTransport({
+      sendRequest: jest.fn().mockRejectedValue(new Error('not supported')),
+    });
+    const docManager = createMockDocumentManager();
+
+    const cacheMap = new Map<string, Diagnostic[]>();
+    const cache: MockDiagnosticsCache = {
+      update: jest.fn((uri: string, items: Diagnostic[]) => {
+        cacheMap.set(uri, items);
+      }),
+      get: jest.fn((uri: string) => cacheMap.get(uri)),
+      // Simulate publishDiagnostics arriving during the first idle wait.
+      waitForIdle: jest.fn().mockImplementation(async () => {
+        cacheMap.set(fileUri, DIAGS_A);
+      }),
+    };
+
+    const state = buildState({
+      transport,
+      documentManager: docManager,
+      diagnosticsCache: cache,
+    });
+
+    const result = await opsGetDiagnostics(state, filePath);
+
+    expect(result).toEqual(DIAGS_A);
+    // The pull request was attempted exactly once with the canonical shape.
+    expect(transport.sendRequest).toHaveBeenCalledTimes(1);
+    expect(transport.sendRequest).toHaveBeenCalledWith('textDocument/diagnostic', {
+      textDocument: { uri: fileUri },
+    });
+    // We exited at the first cache-hit after waitForIdle, so the no-op churn
+    // path must not run.
+    expect(docManager.sendChange).not.toHaveBeenCalled();
+    expect(cache.waitForIdle).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/lsp/operations.result-id.test.ts
+++ b/src/lsp/operations.result-id.test.ts
@@ -1,0 +1,417 @@
+import { describe, expect, it, jest } from 'bun:test';
+import { DiagnosticsCache } from './diagnostics.js';
+import { workspaceDiagnostic } from './operations.js';
+import type {
+  Diagnostic,
+  ServerCapabilities,
+  ServerState,
+  WorkspaceDocumentDiagnosticReport,
+} from './types.js';
+
+/**
+ * PR3 result-id reuse tests for `workspaceDiagnostic`.
+ *
+ *  - First call sends `previousResultIds: []` and stores returned resultIds.
+ *  - Second call sends the prior ids.
+ *  - `kind: 'unchanged'` reports return cached items.
+ *  - Defensive fallback: `unchanged` with no cached entry returns `[]`.
+ *  - Result ids are segmented per `serverState` cache instance.
+ *
+ * Uses a real `DiagnosticsCache` (not a mock) so we exercise the actual
+ * `setResultId` / `getResultId` / `listResultIds` / `update` round-trip.
+ */
+
+interface MockTransport {
+  sendRequest: ReturnType<typeof jest.fn>;
+  sendCancellableRequest: ReturnType<typeof jest.fn>;
+  sendNotification: ReturnType<typeof jest.fn>;
+  sendMessage: ReturnType<typeof jest.fn>;
+  rejectAllPending: ReturnType<typeof jest.fn>;
+  cancelRequest: ReturnType<typeof jest.fn>;
+  registerProgressHandler: ReturnType<typeof jest.fn>;
+  unregisterProgressHandler: ReturnType<typeof jest.fn>;
+}
+
+function createMockTransport(overrides: Partial<MockTransport> = {}): MockTransport {
+  const sendRequest = overrides.sendRequest ?? jest.fn().mockResolvedValue({ items: [] });
+  let nextId = 1;
+  const sendCancellableRequest =
+    overrides.sendCancellableRequest ??
+    jest.fn((method: string, params: unknown, timeout?: number) => {
+      const id = nextId++;
+      const promise = sendRequest(method, params, timeout);
+      return { id, promise };
+    });
+  return {
+    sendRequest,
+    sendCancellableRequest,
+    sendNotification: overrides.sendNotification ?? jest.fn(),
+    sendMessage: overrides.sendMessage ?? jest.fn(),
+    rejectAllPending: overrides.rejectAllPending ?? jest.fn(),
+    cancelRequest: overrides.cancelRequest ?? jest.fn(),
+    registerProgressHandler: overrides.registerProgressHandler ?? jest.fn(),
+    unregisterProgressHandler: overrides.unregisterProgressHandler ?? jest.fn(),
+  };
+}
+
+function createMockDocumentManager(): {
+  ensureOpen: ReturnType<typeof jest.fn>;
+  ensureOpenAsync: ReturnType<typeof jest.fn>;
+  closeDocument: ReturnType<typeof jest.fn>;
+  sendChange: ReturnType<typeof jest.fn>;
+  isOpen: ReturnType<typeof jest.fn>;
+  getVersion: ReturnType<typeof jest.fn>;
+} {
+  return {
+    ensureOpen: jest.fn().mockResolvedValue(false),
+    ensureOpenAsync: jest.fn().mockResolvedValue(false),
+    closeDocument: jest.fn(),
+    sendChange: jest.fn(),
+    isOpen: jest.fn().mockReturnValue(true),
+    getVersion: jest.fn().mockReturnValue(1),
+  };
+}
+
+function buildState(parts: {
+  transport: MockTransport;
+  diagnosticsCache: DiagnosticsCache;
+  capabilities?: ServerCapabilities;
+}): ServerState {
+  return {
+    process: {} as never,
+    transport: parts.transport,
+    documentManager: createMockDocumentManager(),
+    diagnosticsCache: parts.diagnosticsCache,
+    initialized: true,
+    initializationPromise: Promise.resolve(),
+    startTime: Date.now(),
+    config: {
+      extensions: ['ts'],
+      command: ['mock-lsp'],
+    },
+    capabilities: parts.capabilities ?? {
+      diagnosticProvider: { interFileDependencies: true, workspaceDiagnostics: true },
+    },
+    inFlightBatchCount: 0,
+  } as ServerState;
+}
+
+const sampleDiag = (message: string): Diagnostic => ({
+  range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+  severity: 1,
+  message,
+  source: 'mock',
+});
+
+describe('workspaceDiagnostic result-id reuse (PR3)', () => {
+  it('first call sends empty previousResultIds and stores result ids', async () => {
+    const full: WorkspaceDocumentDiagnosticReport[] = [
+      {
+        uri: 'file:///a.ts',
+        kind: 'full',
+        version: 1,
+        resultId: 'rid-A-1',
+        items: [sampleDiag('a-err-1')],
+      },
+      {
+        uri: 'file:///b.ts',
+        kind: 'full',
+        version: 1,
+        resultId: 'rid-B-1',
+        items: [sampleDiag('b-err-1')],
+      },
+    ];
+    const transport = createMockTransport({
+      sendRequest: jest.fn().mockResolvedValue({ items: full }),
+    });
+    const cache = new DiagnosticsCache();
+    const state = buildState({ transport, diagnosticsCache: cache });
+
+    const result = await workspaceDiagnostic(state, { deadline: Date.now() + 5000 });
+
+    expect(result.partial).toBeFalsy();
+    expect(result.items).toHaveLength(2);
+
+    // Pin the request shape: previousResultIds is exactly [].
+    expect(transport.sendRequest).toHaveBeenCalledTimes(1);
+    const firstCall = transport.sendRequest.mock.calls[0];
+    if (!firstCall) throw new Error('expected one sendRequest call');
+    const params = firstCall[1] as {
+      previousResultIds: Array<{ uri: string; value: string }>;
+      partialResultToken: string;
+    };
+    expect(params.previousResultIds).toEqual([]);
+
+    // Cache now holds both result ids and items.
+    expect(cache.getResultId('file:///a.ts')).toBe('rid-A-1');
+    expect(cache.getResultId('file:///b.ts')).toBe('rid-B-1');
+    expect(cache.get('file:///a.ts')).toEqual([sampleDiag('a-err-1')]);
+    expect(cache.get('file:///b.ts')).toEqual([sampleDiag('b-err-1')]);
+
+    // listResultIds returns the snapshot for the next call.
+    const snapshot = cache.listResultIds();
+    expect(snapshot).toHaveLength(2);
+    const sorted = [...snapshot].sort((x, y) => x.uri.localeCompare(y.uri));
+    expect(sorted).toEqual([
+      { uri: 'file:///a.ts', value: 'rid-A-1' },
+      { uri: 'file:///b.ts', value: 'rid-B-1' },
+    ]);
+  });
+
+  it('second call sends prior result ids', async () => {
+    const firstFull: WorkspaceDocumentDiagnosticReport[] = [
+      {
+        uri: 'file:///a.ts',
+        kind: 'full',
+        version: 1,
+        resultId: 'rid-A-1',
+        items: [sampleDiag('a')],
+      },
+      {
+        uri: 'file:///b.ts',
+        kind: 'full',
+        version: 1,
+        resultId: 'rid-B-1',
+        items: [sampleDiag('b')],
+      },
+    ];
+    const secondFull: WorkspaceDocumentDiagnosticReport[] = [
+      {
+        uri: 'file:///a.ts',
+        kind: 'full',
+        version: 2,
+        resultId: 'rid-A-2',
+        items: [sampleDiag('a-updated')],
+      },
+    ];
+    let callCount = 0;
+    const transport = createMockTransport({
+      sendRequest: jest.fn(async () => {
+        callCount++;
+        return { items: callCount === 1 ? firstFull : secondFull };
+      }),
+    });
+    const cache = new DiagnosticsCache();
+    const state = buildState({ transport, diagnosticsCache: cache });
+
+    await workspaceDiagnostic(state, { deadline: Date.now() + 5000 });
+    await workspaceDiagnostic(state, { deadline: Date.now() + 5000 });
+
+    expect(transport.sendRequest).toHaveBeenCalledTimes(2);
+    const secondCall = transport.sendRequest.mock.calls[1];
+    if (!secondCall) throw new Error('expected two sendRequest calls');
+    const params = secondCall[1] as {
+      previousResultIds: Array<{ uri: string; value: string }>;
+    };
+
+    const sorted = [...params.previousResultIds].sort((x, y) => x.uri.localeCompare(y.uri));
+    expect(sorted).toEqual([
+      { uri: 'file:///a.ts', value: 'rid-A-1' },
+      { uri: 'file:///b.ts', value: 'rid-B-1' },
+    ]);
+
+    // After the second call, the cache has the new resultId for a.ts and
+    // still holds the original for b.ts (server did not mention it).
+    expect(cache.getResultId('file:///a.ts')).toBe('rid-A-2');
+    expect(cache.getResultId('file:///b.ts')).toBe('rid-B-1');
+  });
+
+  it('unchanged report returns cached items', async () => {
+    const firstFull: WorkspaceDocumentDiagnosticReport[] = [
+      {
+        uri: 'file:///a.ts',
+        kind: 'full',
+        version: 1,
+        resultId: 'rid-A-1',
+        items: [sampleDiag('cached-a'), sampleDiag('cached-a-2')],
+      },
+    ];
+    const secondUnchanged: WorkspaceDocumentDiagnosticReport[] = [
+      {
+        uri: 'file:///a.ts',
+        kind: 'unchanged',
+        version: 1,
+        resultId: 'rid-A-1',
+      },
+    ];
+    let callCount = 0;
+    const transport = createMockTransport({
+      sendRequest: jest.fn(async () => {
+        callCount++;
+        return { items: callCount === 1 ? firstFull : secondUnchanged };
+      }),
+    });
+    const cache = new DiagnosticsCache();
+    const state = buildState({ transport, diagnosticsCache: cache });
+
+    const r1 = await workspaceDiagnostic(state, { deadline: Date.now() + 5000 });
+    expect(r1.items).toHaveLength(1);
+    expect(r1.items[0]?.items).toHaveLength(2);
+
+    const r2 = await workspaceDiagnostic(state, { deadline: Date.now() + 5000 });
+    expect(r2.partial).toBeFalsy();
+    expect(r2.items).toHaveLength(1);
+    expect(r2.items[0]?.uri).toBe('file:///a.ts');
+    // The unchanged report should yield the same items the cache holds —
+    // i.e. the items we stored on the first call.
+    expect(r2.items[0]?.items).toEqual([sampleDiag('cached-a'), sampleDiag('cached-a-2')]);
+  });
+
+  it('unchanged with no cached entry returns empty for that uri', async () => {
+    // Simulate the edge case where the cache was cleared between calls:
+    // the server returns `unchanged` for a URI we have no items for. The
+    // op must NOT throw — it logs at debug and yields [] for that URI.
+    const onlyUnchanged: WorkspaceDocumentDiagnosticReport[] = [
+      {
+        uri: 'file:///gone.ts',
+        kind: 'unchanged',
+        version: 1,
+        resultId: 'rid-gone-1',
+      },
+    ];
+    const transport = createMockTransport({
+      sendRequest: jest.fn().mockResolvedValue({ items: onlyUnchanged }),
+    });
+    const cache = new DiagnosticsCache();
+    const state = buildState({ transport, diagnosticsCache: cache });
+
+    const result = await workspaceDiagnostic(state, { deadline: Date.now() + 5000 });
+    expect(result.partial).toBeFalsy();
+    expect(result.items).toEqual([{ uri: 'file:///gone.ts', items: [] }]);
+    // We still refresh the resultId so the next call advertises it.
+    expect(cache.getResultId('file:///gone.ts')).toBe('rid-gone-1');
+  });
+
+  it('partial result from cancelled call still populates cache', async () => {
+    // Pin the partial-flush write-through: when the deadline elapses
+    // before the `workspace/diagnostic` request settles, the op classifies
+    // the outcome as `BUDGET` but still routes any `$/progress` partials
+    // through `mergeReports`, which writes `setResultId` + `update` for
+    // each `kind:'full'` entry. The next call must see the cached
+    // resultId + items even though this call never completed.
+    const progressItems: WorkspaceDocumentDiagnosticReport[] = [
+      {
+        uri: 'file:///flushed.ts',
+        kind: 'full',
+        version: 1,
+        resultId: 'p1',
+        items: [sampleDiag('flushed-during-progress')],
+      },
+    ];
+
+    let capturedHandler: ((value: unknown) => void) | undefined;
+    let capturedToken: string | number | undefined;
+
+    // The mock request promise NEVER settles on its own. Progress fires
+    // synchronously when the request is issued; the deadline race is the
+    // only thing that ends the call.
+    const sendRequest = jest.fn(
+      () =>
+        new Promise<unknown>(() => {
+          // Intentionally pending forever.
+        })
+    );
+
+    const transport = createMockTransport({
+      sendRequest,
+      registerProgressHandler: jest.fn(
+        (token: string | number, handler: (value: unknown) => void) => {
+          capturedHandler = handler;
+          capturedToken = token;
+        }
+      ),
+    });
+
+    // Wrap `sendCancellableRequest` so we fire the progress notification
+    // as soon as the request is "issued" (mirrors a real server that
+    // streams partials before the final response).
+    transport.sendCancellableRequest = jest.fn(() => {
+      const id = Math.floor(Math.random() * 1_000_000) + 1;
+      const promise = sendRequest();
+      // Fire `$/progress` right after the handler is registered. The
+      // op registers the handler BEFORE invoking sendCancellableRequest,
+      // so capturedHandler is already set.
+      if (capturedHandler) {
+        capturedHandler({ items: progressItems });
+      }
+      return { id, promise };
+    });
+
+    const cache = new DiagnosticsCache();
+    const state = buildState({ transport, diagnosticsCache: cache });
+
+    // Tiny deadline so the race fires quickly.
+    const result = await workspaceDiagnostic(state, { deadline: Date.now() + 80 });
+
+    // Op returns BUDGET (deadline race rejected via RequestCancelledError).
+    expect(result.partial).toBe(true);
+    expect(result.partialReason).toBe('BUDGET');
+
+    // Despite the cancellation, the cache was populated from the progress
+    // payload — this is the PR3 partial-flush write-through behavior.
+    expect(cache.getResultId('file:///flushed.ts')).toBe('p1');
+    expect(cache.get('file:///flushed.ts')).toEqual([sampleDiag('flushed-during-progress')]);
+
+    // The progress token registered on the transport must match the one
+    // the op generated.
+    expect(typeof capturedToken).toBe('string');
+  });
+
+  it('result ids are segmented per serverKey (separate caches do not bleed)', async () => {
+    // Each ServerState carries its own DiagnosticsCache instance. The PR3
+    // contract uses the per-state cache, so two states with two caches
+    // must not see each other's resultIds.
+    const transportA = createMockTransport({
+      sendRequest: jest.fn().mockResolvedValue({
+        items: [
+          {
+            uri: 'file:///a.ts',
+            kind: 'full',
+            version: 1,
+            resultId: 'rid-A-only',
+            items: [sampleDiag('a')],
+          },
+        ] satisfies WorkspaceDocumentDiagnosticReport[],
+      }),
+    });
+    const transportB = createMockTransport({
+      sendRequest: jest.fn().mockResolvedValue({
+        items: [
+          {
+            uri: 'file:///b.py',
+            kind: 'full',
+            version: 1,
+            resultId: 'rid-B-only',
+            items: [sampleDiag('b')],
+          },
+        ] satisfies WorkspaceDocumentDiagnosticReport[],
+      }),
+    });
+
+    const cacheA = new DiagnosticsCache();
+    const cacheB = new DiagnosticsCache();
+    const stateA = buildState({ transport: transportA, diagnosticsCache: cacheA });
+    const stateB = buildState({ transport: transportB, diagnosticsCache: cacheB });
+
+    await workspaceDiagnostic(stateA, { deadline: Date.now() + 5000 });
+    await workspaceDiagnostic(stateB, { deadline: Date.now() + 5000 });
+
+    expect(cacheA.getResultId('file:///a.ts')).toBe('rid-A-only');
+    expect(cacheA.getResultId('file:///b.py')).toBeUndefined();
+    expect(cacheB.getResultId('file:///b.py')).toBe('rid-B-only');
+    expect(cacheB.getResultId('file:///a.ts')).toBeUndefined();
+
+    // Now drive a SECOND call against each state and assert each only
+    // advertises its own cache.
+    await workspaceDiagnostic(stateA, { deadline: Date.now() + 5000 });
+    await workspaceDiagnostic(stateB, { deadline: Date.now() + 5000 });
+
+    const callA2 = transportA.sendRequest.mock.calls[1];
+    const callB2 = transportB.sendRequest.mock.calls[1];
+    if (!callA2 || !callB2) throw new Error('expected two calls per state');
+    const paramsA = callA2[1] as { previousResultIds: Array<{ uri: string; value: string }> };
+    const paramsB = callB2[1] as { previousResultIds: Array<{ uri: string; value: string }> };
+    expect(paramsA.previousResultIds).toEqual([{ uri: 'file:///a.ts', value: 'rid-A-only' }]);
+    expect(paramsB.previousResultIds).toEqual([{ uri: 'file:///b.py', value: 'rid-B-only' }]);
+  });
+});

--- a/src/lsp/operations.result-id.test.ts
+++ b/src/lsp/operations.result-id.test.ts
@@ -216,6 +216,43 @@ describe('workspaceDiagnostic result-id reuse (PR3)', () => {
     expect(cache.getResultId('file:///b.ts')).toBe('rid-B-1');
   });
 
+  it('clears prior result id when a full report omits resultId', async () => {
+    const firstFull: WorkspaceDocumentDiagnosticReport[] = [
+      {
+        uri: 'file:///a.ts',
+        kind: 'full',
+        version: 1,
+        resultId: 'rid-A-1',
+        items: [sampleDiag('a')],
+      },
+    ];
+    const secondFull: WorkspaceDocumentDiagnosticReport[] = [
+      {
+        uri: 'file:///a.ts',
+        kind: 'full',
+        version: 2,
+        items: [sampleDiag('a-updated')],
+      },
+    ];
+    let callCount = 0;
+    const transport = createMockTransport({
+      sendRequest: jest.fn(async () => {
+        callCount++;
+        return { items: callCount === 1 ? firstFull : secondFull };
+      }),
+    });
+    const cache = new DiagnosticsCache();
+    const state = buildState({ transport, diagnosticsCache: cache });
+
+    await workspaceDiagnostic(state, { deadline: Date.now() + 5000 });
+    expect(cache.getResultId('file:///a.ts')).toBe('rid-A-1');
+
+    await workspaceDiagnostic(state, { deadline: Date.now() + 5000 });
+
+    expect(cache.getResultId('file:///a.ts')).toBeUndefined();
+    expect(cache.listResultIds()).toEqual([]);
+  });
+
   it('unchanged report returns cached items', async () => {
     const firstFull: WorkspaceDocumentDiagnosticReport[] = [
       {

--- a/src/lsp/operations.ts
+++ b/src/lsp/operations.ts
@@ -941,15 +941,25 @@ function deadlineRace<T>(
 }
 
 /**
- * Execute `workspace/diagnostic` against a single server. Always passes
- * `previousResultIds: []` (PR2 day-one contract) and a UUID
- * `partialResultToken`. Accumulates `$/progress` partials and the final
- * response items.
+ * Execute `workspace/diagnostic` against a single server. Always sends a
+ * UUID `partialResultToken` and a non-empty `previousResultIds` array
+ * when the server-state cache has any cached resultIds.
  *
- * Honors `kind: 'unchanged'` reports by treating them as empty (PR2 always
- * sends empty `previousResultIds`, so a server returning "unchanged" is
- * referring to a cache we don't ask it to consult — we'd rather report
- * "no items" than show stale data).
+ * PR3 result-id reuse:
+ *
+ *  - `previousResultIds` defaults to the snapshot returned by
+ *    `serverState.diagnosticsCache.listResultIds()`. Callers can pass an
+ *    explicit array (e.g. tests) to override this. First call returns
+ *    `[]` because no resultIds have been cached yet.
+ *  - For each `kind: 'full'` response entry with a `resultId`, we call
+ *    `setResultId(uri, resultId)` and `update(uri, items)` so subsequent
+ *    calls can request `unchanged` reports.
+ *  - For each `kind: 'unchanged'` response entry, we return the cached
+ *    items via `diagnosticsCache.get(uri)`. If no cache entry exists for
+ *    that URI (e.g. the cache was cleared between calls) we log at
+ *    debug level and return an empty list for that URI.
+ *
+ * Accumulates `$/progress` partials and the final response items.
  */
 export async function workspaceDiagnostic(
   serverState: ServerState,
@@ -960,7 +970,12 @@ export async function workspaceDiagnostic(
   }
 ): Promise<WorkspaceDiagnosticOpResult> {
   const { deadline } = options;
-  const previousResultIds = options.previousResultIds ?? [];
+  // PR3: build previousResultIds from the per-server cache when the caller
+  // does not supply one. This is the day-three contract — every workspace
+  // pull from now on advertises whatever resultIds we have cached so the
+  // server can answer with `kind: 'unchanged'` for unchanged files.
+  const previousResultIds =
+    options.previousResultIds ?? serverState.diagnosticsCache.listResultIds?.() ?? [];
   const partialResultToken = randomUUID();
 
   await serverState.initializationPromise;
@@ -1030,7 +1045,7 @@ export async function workspaceDiagnostic(
       if (isCancelledError(err)) {
         logger.debug('[DEBUG workspaceDiagnostic] Request cancelled (BUDGET)\n');
         return {
-          items: mergeReports(partials, undefined),
+          items: mergeReports(serverState, partials, undefined),
           partial: true,
           partialReason: 'BUDGET',
         };
@@ -1038,14 +1053,14 @@ export async function workspaceDiagnostic(
       // Server crash / process exit / generic LSP error.
       logger.debug(`[DEBUG workspaceDiagnostic] Request error: ${err}\n`);
       return {
-        items: mergeReports(partials, undefined),
+        items: mergeReports(serverState, partials, undefined),
         partial: true,
         partialReason: 'SERVER_CRASH',
       };
     }
 
     return {
-      items: mergeReports(partials, response?.items ?? []),
+      items: mergeReports(serverState, partials, response?.items ?? []),
     };
   } finally {
     transport.unregisterProgressHandler?.(partialResultToken);
@@ -1055,24 +1070,55 @@ export async function workspaceDiagnostic(
 /**
  * Convert a list of `WorkspaceDocumentDiagnosticReport` entries (partials
  * + final) into the flat `DiagnosticsByFile[]` shape used by the tool
- * layer. `'unchanged'` reports are treated as empty in PR2.
+ * layer.
+ *
+ * PR3 result-id reuse:
+ *
+ *  - `kind: 'full'` entries with a `resultId` are stored via
+ *    `diagnosticsCache.setResultId(uri, resultId)` and the items are
+ *    written through `diagnosticsCache.update(uri, items)` so a later
+ *    `unchanged` report can be answered from the cache.
+ *  - `kind: 'unchanged'` entries return the cached items via
+ *    `diagnosticsCache.get(uri)`. When no cache entry exists for the URI
+ *    (e.g. the cache was cleared between calls), we log at debug level
+ *    and return an empty list for that URI as a defensive fallback.
  */
 function mergeReports(
+  serverState: ServerState,
   partials: WorkspaceDocumentDiagnosticReport[],
   finalItems: WorkspaceDocumentDiagnosticReport[] | undefined
 ): DiagnosticsByFile[] {
   const byUri = new Map<string, Diagnostic[]>();
+  const cache = serverState.diagnosticsCache;
   const consume = (entries: WorkspaceDocumentDiagnosticReport[]): void => {
     for (const entry of entries) {
       if (!entry || !entry.uri) continue;
       if (entry.kind === 'full') {
+        const items = entry.items ?? [];
         // Later "full" reports for the same URI overwrite earlier ones.
-        byUri.set(entry.uri, entry.items ?? []);
+        byUri.set(entry.uri, items);
+        // Persist the resultId + items so a later call can request
+        // `unchanged` reports against them.
+        if (entry.resultId && cache.setResultId) {
+          cache.setResultId(entry.uri, entry.resultId);
+        }
+        // Always write through items so `kind: 'unchanged'` reuse on the
+        // next call has fresh data, even when the server omitted resultId.
+        cache.update(entry.uri, items);
       } else if (entry.kind === 'unchanged') {
-        logger.debug(
-          `[DEBUG workspaceDiagnostic] kind:'unchanged' for ${entry.uri} (PR2 treats as empty)\n`
-        );
-        if (!byUri.has(entry.uri)) byUri.set(entry.uri, []);
+        const cached = cache.get(entry.uri);
+        if (cached !== undefined) {
+          byUri.set(entry.uri, cached);
+        } else {
+          logger.debug(
+            `[DEBUG workspaceDiagnostic] kind:'unchanged' for ${entry.uri} with no cached entry; returning []\n`
+          );
+          if (!byUri.has(entry.uri)) byUri.set(entry.uri, []);
+        }
+        // Refresh the resultId so the server's latest opaque token wins.
+        if (entry.resultId && cache.setResultId) {
+          cache.setResultId(entry.uri, entry.resultId);
+        }
       }
     }
   };

--- a/src/lsp/operations.ts
+++ b/src/lsp/operations.ts
@@ -1,21 +1,56 @@
+import { randomUUID } from 'node:crypto';
 import { readFileSync } from 'node:fs';
 import { logger } from '../logger.js';
 import { pathToUri, uriToPath } from '../utils.js';
+import { LSPRequestTimeoutError, RequestCancelledError } from './json-rpc.js';
 import type {
   CallHierarchyIncomingCall,
   CallHierarchyItem,
   CallHierarchyOutgoingCall,
   Diagnostic,
+  DiagnosticsByFile,
   DocumentDiagnosticReport,
   DocumentSymbol,
   LSPLocation,
   Location,
+  PerFileBatchResult,
   Position,
+  PreviousResultId,
   ServerState,
   SymbolInformation,
   SymbolMatch,
+  WorkspaceDiagnosticOpResult,
+  WorkspaceDiagnosticReport,
+  WorkspaceDiagnosticReportPartialResult,
+  WorkspaceDocumentDiagnosticReport,
 } from './types.js';
 import { SymbolKind } from './types.js';
+
+/**
+ * Default per-server concurrency for `perFilePullBatch` and
+ * `pushFallbackBatch`. Tunable constant per the plan.
+ */
+export const BATCH_FILE_CONCURRENCY = 2;
+
+/**
+ * Minimum per-request timeout for batch paths. If less than this much
+ * budget remains, we drop the file instead of issuing the request.
+ */
+const MIN_PER_REQ_MS = 250;
+
+/**
+ * Default upper-bound timeout used when no adapter overrides it. Mirrors
+ * the default in the single-file ops.
+ */
+const DEFAULT_OP_TIMEOUT_MS = 30000;
+
+/**
+ * Maximum time we wait after the deadline for `closeDocument` cleanup and
+ * any cancellation rejections to settle before returning the bucket
+ * result. Pure safety net — under normal operation the rejects resolve
+ * synchronously inside `cancelRequest`.
+ */
+const CANCEL_GRACE_MS = 100;
 
 // --- Symbol Utilities ---
 
@@ -817,4 +852,572 @@ export async function outgoingCalls(
   }
 
   return [];
+}
+
+// --- Batch diagnostics operations (PR2) ----------------------------------
+
+/**
+ * Compute the per-request timeout from the shared deadline and an optional
+ * adapter-provided upper bound. Returns `null` when the remaining budget is
+ * below `MIN_PER_REQ_MS` (caller should drop the request as BUDGET).
+ */
+function computeBatchTimeout(
+  serverState: ServerState,
+  method: string,
+  deadline: number
+): number | null {
+  const remaining = deadline - Date.now();
+  if (remaining < MIN_PER_REQ_MS) return null;
+  const adapterMax = serverState.adapter?.getTimeout?.(method) ?? DEFAULT_OP_TIMEOUT_MS;
+  return Math.max(MIN_PER_REQ_MS, Math.min(adapterMax, remaining));
+}
+
+/**
+ * Returns true when an error from the transport is a *cancellation* (i.e.
+ * the batch path treats it as BUDGET, not SERVER_CRASH). This covers:
+ *
+ *  - `RequestCancelledError`: explicit `$/cancelRequest` via
+ *    `transport.cancelRequest(id)` at deadline.
+ *  - `LSPRequestTimeoutError`: the transport's per-request timer elapsed.
+ *    Batch paths pass very generous per-request timeouts and rely on the
+ *    deadline race + cancel propagation; if the internal timer still
+ *    fires, it's still a budget condition, not a server crash.
+ */
+function isCancelledError(err: unknown): boolean {
+  return err instanceof RequestCancelledError || err instanceof LSPRequestTimeoutError;
+}
+
+/**
+ * Returns true when an error from the transport is specifically the
+ * per-request timeout (separate from explicit cancellation).
+ */
+export function isTimeoutError(err: unknown): boolean {
+  return err instanceof LSPRequestTimeoutError;
+}
+
+/**
+ * Race `promise` against the shared deadline. If the deadline elapses, the
+ * returned promise rejects with `RequestCancelledError` and `onDeadline()`
+ * fires so the caller can propagate the cancellation to the transport
+ * (e.g., `transport.cancelRequest(id)` and/or aborting an AbortController).
+ *
+ * The original promise is NOT awaited after rejection; callers must ensure
+ * any cleanup happens via `onDeadline`.
+ */
+function deadlineRace<T>(
+  promise: Promise<T>,
+  deadline: number,
+  onDeadline?: () => void
+): Promise<T> {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let settled = false;
+  return new Promise<T>((resolve, reject) => {
+    const ms = Math.max(0, deadline - Date.now());
+    timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        onDeadline?.();
+      } catch (e) {
+        logger.debug(`[DEBUG deadlineRace] onDeadline threw: ${e}\n`);
+      }
+      reject(new RequestCancelledError(-1));
+    }, ms);
+    promise.then(
+      (v) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        if (settled) return;
+        settled = true;
+        if (timer) clearTimeout(timer);
+        reject(e);
+      }
+    );
+  });
+}
+
+/**
+ * Execute `workspace/diagnostic` against a single server. Always passes
+ * `previousResultIds: []` (PR2 day-one contract) and a UUID
+ * `partialResultToken`. Accumulates `$/progress` partials and the final
+ * response items.
+ *
+ * Honors `kind: 'unchanged'` reports by treating them as empty (PR2 always
+ * sends empty `previousResultIds`, so a server returning "unchanged" is
+ * referring to a cache we don't ask it to consult — we'd rather report
+ * "no items" than show stale data).
+ */
+export async function workspaceDiagnostic(
+  serverState: ServerState,
+  options: {
+    deadline: number;
+    previousResultIds?: PreviousResultId[];
+    workspaceFolders?: string[];
+  }
+): Promise<WorkspaceDiagnosticOpResult> {
+  const { deadline } = options;
+  const previousResultIds = options.previousResultIds ?? [];
+  const partialResultToken = randomUUID();
+
+  await serverState.initializationPromise;
+
+  const method = 'workspace/diagnostic';
+  if (Date.now() >= deadline) {
+    logger.debug('[DEBUG workspaceDiagnostic] Deadline already elapsed; dropping with BUDGET\n');
+    return {
+      items: [],
+      partial: true,
+      partialReason: 'BUDGET',
+    };
+  }
+
+  // The per-request timer should practically never fire — the deadline
+  // race below is what enforces the wall-clock budget. We still pass an
+  // upper-bound timeout so a hung connection eventually surfaces via
+  // `LSPRequestTimeoutError` (which `isCancelledError` classifies as
+  // BUDGET).
+  const adapterMax = serverState.adapter?.getTimeout?.(method) ?? DEFAULT_OP_TIMEOUT_MS;
+  const remaining = deadline - Date.now();
+  const generousTimeout = Math.max(adapterMax, remaining) + CANCEL_GRACE_MS * 2;
+
+  const partials: WorkspaceDocumentDiagnosticReport[] = [];
+  const progressHandler = (value: unknown): void => {
+    const partial = value as WorkspaceDiagnosticReportPartialResult | undefined;
+    if (partial?.items && Array.isArray(partial.items)) {
+      partials.push(...partial.items);
+    }
+  };
+
+  const transport = serverState.transport;
+  transport.registerProgressHandler?.(partialResultToken, progressHandler);
+
+  try {
+    const params = {
+      previousResultIds,
+      partialResultToken,
+    };
+
+    // Prefer `sendCancellableRequest` if the transport exposes it so we
+    // can wire $/cancelRequest at the deadline. Fall back to the legacy
+    // `sendRequest` for older mock transports in tests.
+    let id: number | undefined;
+    let promise: Promise<unknown>;
+    if (transport.sendCancellableRequest) {
+      const handle = transport.sendCancellableRequest(method, params, generousTimeout);
+      id = handle.id;
+      promise = handle.promise;
+    } else {
+      promise = transport.sendRequest(method, params, generousTimeout);
+    }
+
+    let response: WorkspaceDiagnosticReport | undefined;
+    try {
+      const raw = await deadlineRace(promise, deadline, () => {
+        if (id !== undefined) {
+          try {
+            transport.cancelRequest?.(id);
+          } catch (e) {
+            logger.debug(`[DEBUG workspaceDiagnostic] cancelRequest threw: ${e}\n`);
+          }
+        }
+      });
+      response = raw as WorkspaceDiagnosticReport;
+    } catch (err) {
+      if (isCancelledError(err)) {
+        logger.debug('[DEBUG workspaceDiagnostic] Request cancelled (BUDGET)\n');
+        return {
+          items: mergeReports(partials, undefined),
+          partial: true,
+          partialReason: 'BUDGET',
+        };
+      }
+      // Server crash / process exit / generic LSP error.
+      logger.debug(`[DEBUG workspaceDiagnostic] Request error: ${err}\n`);
+      return {
+        items: mergeReports(partials, undefined),
+        partial: true,
+        partialReason: 'SERVER_CRASH',
+      };
+    }
+
+    return {
+      items: mergeReports(partials, response?.items ?? []),
+    };
+  } finally {
+    transport.unregisterProgressHandler?.(partialResultToken);
+  }
+}
+
+/**
+ * Convert a list of `WorkspaceDocumentDiagnosticReport` entries (partials
+ * + final) into the flat `DiagnosticsByFile[]` shape used by the tool
+ * layer. `'unchanged'` reports are treated as empty in PR2.
+ */
+function mergeReports(
+  partials: WorkspaceDocumentDiagnosticReport[],
+  finalItems: WorkspaceDocumentDiagnosticReport[] | undefined
+): DiagnosticsByFile[] {
+  const byUri = new Map<string, Diagnostic[]>();
+  const consume = (entries: WorkspaceDocumentDiagnosticReport[]): void => {
+    for (const entry of entries) {
+      if (!entry || !entry.uri) continue;
+      if (entry.kind === 'full') {
+        // Later "full" reports for the same URI overwrite earlier ones.
+        byUri.set(entry.uri, entry.items ?? []);
+      } else if (entry.kind === 'unchanged') {
+        logger.debug(
+          `[DEBUG workspaceDiagnostic] kind:'unchanged' for ${entry.uri} (PR2 treats as empty)\n`
+        );
+        if (!byUri.has(entry.uri)) byUri.set(entry.uri, []);
+      }
+    }
+  };
+  consume(partials);
+  if (finalItems) consume(finalItems);
+  return Array.from(byUri.entries()).map(([uri, items]) => ({ uri, items }));
+}
+
+/**
+ * Run a small concurrent worker pool over `files`, calling `worker(file)`
+ * for each. Stops dispatching new work once `Date.now() >= deadline`. The
+ * worker is responsible for honoring the deadline itself when issuing
+ * LSP requests; this pool only gates *new* dispatches.
+ *
+ * Returns `{ inFlightTracker }` so the caller can observe the maximum
+ * concurrency reached in tests (the value is the peak count). The pool
+ * always completes after every dispatched worker settles (resolve or
+ * reject) so cleanup can run in a `finally`.
+ */
+async function runWithConcurrency<T, R>(
+  items: T[],
+  concurrency: number,
+  deadline: number,
+  worker: (item: T, signal: { cancelled: boolean }) => Promise<R>
+): Promise<{ results: Array<{ item: T; value?: R; error?: unknown }>; peakInFlight: number }> {
+  const results: Array<{ item: T; value?: R; error?: unknown }> = [];
+  let index = 0;
+  let inFlight = 0;
+  let peakInFlight = 0;
+  const signal = { cancelled: false };
+
+  const workersDone: Promise<void>[] = [];
+
+  const launchOne = async (): Promise<void> => {
+    while (true) {
+      if (signal.cancelled) return;
+      const i = index++;
+      if (i >= items.length) return;
+      if (Date.now() >= deadline) {
+        // Budget elapsed; record remaining as drops.
+        signal.cancelled = true;
+        return;
+      }
+      const item = items[i];
+      if (item === undefined) return;
+      inFlight++;
+      if (inFlight > peakInFlight) peakInFlight = inFlight;
+      try {
+        const value = await worker(item, signal);
+        results.push({ item, value });
+      } catch (error) {
+        results.push({ item, error });
+      } finally {
+        inFlight--;
+      }
+    }
+  };
+
+  const slots = Math.max(1, Math.min(concurrency, items.length));
+  for (let s = 0; s < slots; s++) {
+    workersDone.push(launchOne());
+  }
+  await Promise.all(workersDone);
+
+  return { results, peakInFlight };
+}
+
+/**
+ * Result returned by per-file fetchers to {@link runPerFileBucket}.
+ * `items` is the list of diagnostics for the file's URI.
+ */
+interface PerFileFetcherResult {
+  uri: string;
+  items: Diagnostic[];
+}
+
+/**
+ * Helpers a per-file fetcher receives from {@link runPerFileBucket}. The
+ * fetcher must use these so the bucket can propagate cancellation cleanly:
+ *
+ *  - `signal`: aborted when the deadline elapses. Pass to
+ *    `waitForIdle` and check before issuing new work.
+ *  - `runCancellable(method, params, timeout)`: wraps
+ *    `transport.sendCancellableRequest` (or `sendRequest`) and races against
+ *    the shared deadline. On timeout it calls `transport.cancelRequest(id)`
+ *    so the server frees its slot.
+ */
+interface PerFileFetcherHelpers {
+  signal: AbortSignal;
+  runCancellable: (method: string, params: unknown, timeout: number) => Promise<unknown>;
+}
+
+/**
+ * Shared per-file bucket worker pool. Owns the open/close discipline,
+ * dropCount bookkeeping, partial-flag aggregation, and deadline-driven
+ * cancellation. {@link perFilePullBatch} and {@link pushFallbackBatch} are
+ * thin wrappers supplying different fetchers.
+ */
+async function runPerFileBucket(
+  serverState: ServerState,
+  files: string[],
+  options: {
+    deadline: number;
+    concurrency?: number;
+    includeUnopened?: boolean;
+    logTag: string;
+  },
+  fetcher: (
+    filePath: string,
+    deadline: number,
+    helpers: PerFileFetcherHelpers
+  ) => Promise<PerFileFetcherResult>
+): Promise<PerFileBatchResult> {
+  const { deadline, logTag } = options;
+  const concurrency = options.concurrency ?? BATCH_FILE_CONCURRENCY;
+  const includeUnopened = options.includeUnopened ?? true;
+
+  await serverState.initializationPromise;
+
+  const openedByMe = new Set<string>();
+  const closedByMe = new Set<string>();
+  const items: DiagnosticsByFile[] = [];
+  let dropsBudget = 0;
+  let dropsCrash = 0;
+  let dropsUnreadable = 0;
+  let dropsNotOpen = 0;
+
+  const worker = async (file: string): Promise<void> => {
+    if (closedByMe.has(file)) {
+      // One-shot guarantee: do not reopen a file we already closed.
+      return;
+    }
+    const wasOpen = serverState.documentManager.isOpen(file);
+    if (!wasOpen && !includeUnopened) {
+      dropsNotOpen++;
+      return;
+    }
+
+    try {
+      if (!wasOpen) {
+        if (serverState.documentManager.ensureOpenAsync) {
+          await serverState.documentManager.ensureOpenAsync(file);
+        } else {
+          await serverState.documentManager.ensureOpen(file);
+        }
+        openedByMe.add(file);
+      }
+    } catch (err) {
+      logger.debug(`[DEBUG ${logTag}] Could not open ${file}: ${err}\n`);
+      dropsUnreadable++;
+      return;
+    }
+
+    const remaining = deadline - Date.now();
+    if (remaining < MIN_PER_REQ_MS) {
+      dropsBudget++;
+      if (openedByMe.has(file)) {
+        serverState.documentManager.closeDocument?.(file);
+        openedByMe.delete(file);
+        closedByMe.add(file);
+      }
+      return;
+    }
+
+    // Per-file AbortController tied to the shared deadline. Used by the
+    // fetcher to short-circuit `waitForIdle` calls and any other awaits
+    // that accept an AbortSignal.
+    const controller = new AbortController();
+
+    const runCancellable = async (
+      method: string,
+      params: unknown,
+      timeout: number
+    ): Promise<unknown> => {
+      const transport = serverState.transport;
+      let id: number | undefined;
+      let promise: Promise<unknown>;
+      if (transport.sendCancellableRequest) {
+        const handle = transport.sendCancellableRequest(method, params, timeout);
+        id = handle.id;
+        promise = handle.promise;
+      } else {
+        promise = transport.sendRequest(method, params, timeout);
+      }
+      return deadlineRace(promise, deadline, () => {
+        if (id !== undefined) {
+          try {
+            transport.cancelRequest?.(id);
+          } catch (e) {
+            logger.debug(`[DEBUG ${logTag}] cancelRequest threw: ${e}\n`);
+          }
+        }
+        controller.abort();
+      });
+    };
+
+    try {
+      const result = await fetcher(file, deadline, {
+        signal: controller.signal,
+        runCancellable,
+      });
+      items.push({ uri: result.uri, items: result.items });
+    } catch (err) {
+      if (isCancelledError(err)) {
+        controller.abort();
+        dropsBudget++;
+      } else {
+        logger.debug(`[DEBUG ${logTag}] Fetcher error for ${file}: ${err}\n`);
+        dropsCrash++;
+      }
+    } finally {
+      // Always abort to release any lingering signal-driven waits.
+      if (!controller.signal.aborted) controller.abort();
+      if (openedByMe.has(file)) {
+        serverState.documentManager.closeDocument?.(file);
+        openedByMe.delete(file);
+        closedByMe.add(file);
+      }
+    }
+  };
+
+  await runWithConcurrency(files, concurrency, deadline, worker);
+
+  // Anything not dispatched counts as BUDGET drop (deadline elapsed).
+  const dispatched = items.length + dropsBudget + dropsCrash + dropsUnreadable + dropsNotOpen;
+  const remaining = Math.max(0, files.length - dispatched);
+  dropsBudget += remaining;
+
+  let partial = false;
+  let partialReason: PerFileBatchResult['partialReason'] | undefined;
+  if (dropsCrash > 0) {
+    partial = true;
+    partialReason = 'SERVER_CRASH';
+  } else if (dropsBudget > 0) {
+    partial = true;
+    partialReason = 'BUDGET';
+  }
+
+  return {
+    items,
+    partial,
+    partialReason,
+    droppedCounts: {
+      budget: dropsBudget,
+      unreadable: dropsUnreadable,
+      serverCrash: dropsCrash,
+      notOpen: dropsNotOpen,
+    },
+  };
+}
+
+/**
+ * Per-file pull batch: for each file, open if needed → send
+ * `textDocument/diagnostic` → close if we opened it. One-shot per batch
+ * (R3) — a file we closed is NEVER re-opened in the same batch.
+ */
+export async function perFilePullBatch(
+  serverState: ServerState,
+  files: string[],
+  options: {
+    deadline: number;
+    concurrency?: number;
+    includeUnopened?: boolean;
+  }
+): Promise<PerFileBatchResult> {
+  return runPerFileBucket(
+    serverState,
+    files,
+    { ...options, logTag: 'perFilePullBatch' },
+    async (file, deadline, helpers) => {
+      const method = 'textDocument/diagnostic';
+      const timeout = computeBatchTimeout(serverState, method, deadline);
+      if (timeout === null) {
+        // Surface BUDGET via RequestCancelledError so the bucket counts
+        // this as a budget drop, not a crash.
+        throw new RequestCancelledError(-1);
+      }
+
+      const uri = pathToUri(file);
+      const raw = await helpers.runCancellable(method, { textDocument: { uri } }, timeout);
+
+      if (raw && typeof raw === 'object' && 'kind' in raw) {
+        const report = raw as DocumentDiagnosticReport;
+        if (report.kind === 'full') return { uri, items: report.items ?? [] };
+        return { uri, items: [] };
+      }
+      return { uri, items: [] };
+    }
+  );
+}
+
+/**
+ * Push fallback batch: for servers that advertise neither
+ * `textDocument/diagnostic` nor `workspace/diagnostic`. For each file:
+ * open if not already open → `waitForIdle` to collect `publishDiagnostics`
+ * → close if we opened it. One-shot per batch.
+ */
+export async function pushFallbackBatch(
+  serverState: ServerState,
+  files: string[],
+  options: {
+    deadline: number;
+    concurrency?: number;
+    includeUnopened?: boolean;
+  }
+): Promise<PerFileBatchResult> {
+  return runPerFileBucket(
+    serverState,
+    files,
+    { ...options, logTag: 'pushFallbackBatch' },
+    async (file, deadline, helpers) => {
+      const uri = pathToUri(file);
+      const remaining = deadline - Date.now();
+      if (remaining < MIN_PER_REQ_MS) {
+        throw new RequestCancelledError(-1);
+      }
+      const maxWaitTime = Math.max(MIN_PER_REQ_MS, Math.min(remaining, 5000));
+
+      // Race the wait against the shared deadline. The signal lets
+      // `waitForIdle` return immediately on cancellation rather than
+      // running its own poll loop to completion.
+      try {
+        await deadlineRace(
+          serverState.diagnosticsCache.waitForIdle(uri, {
+            maxWaitTime,
+            idleTime: 300,
+            signal: helpers.signal,
+          }),
+          deadline
+        );
+      } catch (err) {
+        // If the deadline fired but we already have cached diagnostics
+        // (e.g., the server published before the budget elapsed), surface
+        // them instead of counting this as a drop.
+        if (isCancelledError(err)) {
+          const cached = serverState.diagnosticsCache.get(uri);
+          if (cached !== undefined) {
+            return { uri, items: cached };
+          }
+        }
+        throw err;
+      }
+
+      const cached = serverState.diagnosticsCache.get(uri);
+      return { uri, items: cached ?? [] };
+    }
+  );
 }

--- a/src/lsp/operations.ts
+++ b/src/lsp/operations.ts
@@ -1099,8 +1099,8 @@ function mergeReports(
         byUri.set(entry.uri, items);
         // Persist the resultId + items so a later call can request
         // `unchanged` reports against them.
-        if (entry.resultId && cache.setResultId) {
-          cache.setResultId(entry.uri, entry.resultId);
+        if (cache.setResultId) {
+          cache.setResultId(entry.uri, entry.resultId ?? '');
         }
         // Always write through items so `kind: 'unchanged'` reuse on the
         // next call has fresh data, even when the server omitted resultId.
@@ -1116,8 +1116,8 @@ function mergeReports(
           if (!byUri.has(entry.uri)) byUri.set(entry.uri, []);
         }
         // Refresh the resultId so the server's latest opaque token wins.
-        if (entry.resultId && cache.setResultId) {
-          cache.setResultId(entry.uri, entry.resultId);
+        if (cache.setResultId) {
+          cache.setResultId(entry.uri, entry.resultId ?? '');
         }
       }
     }
@@ -1259,12 +1259,10 @@ async function runPerFileBucket(
 
     try {
       if (!wasOpen) {
-        if (serverState.documentManager.ensureOpenAsync) {
-          await serverState.documentManager.ensureOpenAsync(file);
-        } else {
-          await serverState.documentManager.ensureOpen(file);
-        }
-        openedByMe.add(file);
+        const opened = serverState.documentManager.ensureOpenAsync
+          ? await serverState.documentManager.ensureOpenAsync(file)
+          : await serverState.documentManager.ensureOpen(file);
+        if (opened) openedByMe.add(file);
       }
     } catch (err) {
       logger.debug(`[DEBUG ${logTag}] Could not open ${file}: ${err}\n`);

--- a/src/lsp/server-manager.capabilities.test.ts
+++ b/src/lsp/server-manager.capabilities.test.ts
@@ -64,8 +64,8 @@ describe('ServerManager capabilities capture', () => {
     manager = new ServerManager();
   });
 
-  afterEach(() => {
-    manager.dispose();
+  afterEach(async () => {
+    await manager.dispose();
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 
@@ -176,8 +176,8 @@ describe('ServerManager client capabilities in initialize params', () => {
     manager = new ServerManager();
   });
 
-  afterEach(() => {
-    manager.dispose();
+  afterEach(async () => {
+    await manager.dispose();
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 

--- a/src/lsp/server-manager.capabilities.test.ts
+++ b/src/lsp/server-manager.capabilities.test.ts
@@ -1,0 +1,258 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ServerManager } from './server-manager.js';
+import type { LSPServerConfig } from './types.js';
+
+/** Write a file using Bun.write to avoid node:fs mock interference. */
+async function writeFile(path: string, content: string): Promise<void> {
+  await Bun.write(path, content);
+}
+
+/**
+ * A tiny mock LSP server: reads Content-Length framed JSON-RPC messages from
+ * stdin and writes a corresponding framed initialize response. Capabilities
+ * returned in the response are controlled by `capsJson` (passed via argv).
+ */
+function makeMockServerScript(capsJson: string): string {
+  return `
+const caps = ${capsJson};
+let buf = '';
+process.stdin.on('data', (chunk) => {
+  buf += chunk.toString();
+  while (true) {
+    const idx = buf.indexOf('\\r\\n\\r\\n');
+    if (idx < 0) return;
+    const header = buf.slice(0, idx);
+    const m = header.match(/Content-Length: (\\d+)/);
+    if (!m) { buf = buf.slice(idx + 4); continue; }
+    const len = parseInt(m[1], 10);
+    const start = idx + 4;
+    if (buf.length < start + len) return;
+    const body = buf.slice(start, start + len);
+    buf = buf.slice(start + len);
+    let msg;
+    try { msg = JSON.parse(body); } catch { continue; }
+    if (msg.method === 'initialize') {
+      const response = JSON.stringify({
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: caps === null
+          ? null
+          : { capabilities: caps },
+      });
+      const out = 'Content-Length: ' + Buffer.byteLength(response) + '\\r\\n\\r\\n' + response;
+      process.stdout.write(out);
+      // Also send 'initialized' notification back to mark startup complete.
+      const notif = JSON.stringify({ jsonrpc: '2.0', method: 'initialized', params: {} });
+      const outN = 'Content-Length: ' + Buffer.byteLength(notif) + '\\r\\n\\r\\n' + notif;
+      process.stdout.write(outN);
+    }
+  }
+});
+process.stdin.on('end', () => process.exit(0));
+`;
+}
+
+describe('ServerManager capabilities capture', () => {
+  let TEST_DIR: string;
+  let manager: ServerManager;
+
+  beforeEach(() => {
+    TEST_DIR = mkdtempSync(join(tmpdir(), 'cclsp-srvmgr-caps-'));
+    manager = new ServerManager();
+  });
+
+  afterEach(() => {
+    manager.dispose();
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  async function runWithCaps(capsJson: string): Promise<LSPServerConfig> {
+    const scriptPath = join(TEST_DIR, 'mock-server.cjs');
+    await writeFile(scriptPath, makeMockServerScript(capsJson));
+    return {
+      extensions: ['ts'],
+      command: ['node', scriptPath],
+      rootDir: TEST_DIR,
+    };
+  }
+
+  it('captures diagnosticProvider boolean from initialize response', async () => {
+    const config = await runWithCaps(JSON.stringify({ diagnosticProvider: true }));
+    const state = await manager.getServer(config);
+
+    expect(state.capabilities).toBeDefined();
+    expect(state.capabilities?.diagnosticProvider).toBe(true);
+  });
+
+  it('captures full DiagnosticOptions object form', async () => {
+    const config = await runWithCaps(
+      JSON.stringify({
+        diagnosticProvider: {
+          identifier: 'mock',
+          interFileDependencies: true,
+          workspaceDiagnostics: true,
+        },
+      })
+    );
+    const state = await manager.getServer(config);
+
+    expect(state.capabilities?.diagnosticProvider).toEqual({
+      identifier: 'mock',
+      interFileDependencies: true,
+      workspaceDiagnostics: true,
+    });
+  });
+
+  it('leaves capabilities undefined when initialize returns no capabilities key', async () => {
+    // Server returns null result entirely.
+    const config = await runWithCaps('null');
+    const state = await manager.getServer(config);
+
+    expect(state.capabilities).toBeUndefined();
+  });
+
+  it('leaves capabilities undefined when initialize returns an empty object (no capabilities key)', async () => {
+    // Use a custom mock that returns `result: {}` rather than the
+    // `{ capabilities: <caps> }` shape produced by makeMockServerScript.
+    const scriptPath = join(TEST_DIR, 'empty-result.cjs');
+    const script = `
+let buf = '';
+process.stdin.on('data', (chunk) => {
+  buf += chunk.toString();
+  while (true) {
+    const idx = buf.indexOf('\\r\\n\\r\\n');
+    if (idx < 0) return;
+    const header = buf.slice(0, idx);
+    const m = header.match(/Content-Length: (\\d+)/);
+    if (!m) { buf = buf.slice(idx + 4); continue; }
+    const len = parseInt(m[1], 10);
+    const start = idx + 4;
+    if (buf.length < start + len) return;
+    const body = buf.slice(start, start + len);
+    buf = buf.slice(start + len);
+    let msg;
+    try { msg = JSON.parse(body); } catch { continue; }
+    if (msg.method === 'initialize') {
+      const response = JSON.stringify({ jsonrpc: '2.0', id: msg.id, result: {} });
+      const out = 'Content-Length: ' + Buffer.byteLength(response) + '\\r\\n\\r\\n' + response;
+      process.stdout.write(out);
+      const notif = JSON.stringify({ jsonrpc: '2.0', method: 'initialized', params: {} });
+      const outN = 'Content-Length: ' + Buffer.byteLength(notif) + '\\r\\n\\r\\n' + notif;
+      process.stdout.write(outN);
+    }
+  }
+});
+process.stdin.on('end', () => process.exit(0));
+`;
+    await writeFile(scriptPath, script);
+
+    const config: LSPServerConfig = {
+      extensions: ['ts'],
+      command: ['node', scriptPath],
+      rootDir: TEST_DIR,
+    };
+    const state = await manager.getServer(config);
+
+    expect(state.capabilities).toBeUndefined();
+  });
+
+  it('inFlightBatchCount is initialized to 0', async () => {
+    const config = await runWithCaps(JSON.stringify({ diagnosticProvider: true }));
+    const state = await manager.getServer(config);
+
+    expect(state.inFlightBatchCount).toBe(0);
+  });
+});
+
+describe('ServerManager client capabilities in initialize params', () => {
+  let TEST_DIR: string;
+  let manager: ServerManager;
+
+  beforeEach(() => {
+    TEST_DIR = mkdtempSync(join(tmpdir(), 'cclsp-srvmgr-clientcaps-'));
+    manager = new ServerManager();
+  });
+
+  afterEach(() => {
+    manager.dispose();
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  it('initialize params include workspace.diagnostics and textDocument.diagnostic', async () => {
+    // Capturing server: writes the initialize params back to a side-channel file.
+    const sidePath = join(TEST_DIR, 'init-params.json');
+    const scriptPath = join(TEST_DIR, 'capture.cjs');
+    const script = `
+const fs = require('fs');
+let buf = '';
+process.stdin.on('data', (chunk) => {
+  buf += chunk.toString();
+  while (true) {
+    const idx = buf.indexOf('\\r\\n\\r\\n');
+    if (idx < 0) return;
+    const header = buf.slice(0, idx);
+    const m = header.match(/Content-Length: (\\d+)/);
+    if (!m) { buf = buf.slice(idx + 4); continue; }
+    const len = parseInt(m[1], 10);
+    const start = idx + 4;
+    if (buf.length < start + len) return;
+    const body = buf.slice(start, start + len);
+    buf = buf.slice(start + len);
+    let msg;
+    try { msg = JSON.parse(body); } catch { continue; }
+    if (msg.method === 'initialize') {
+      fs.writeFileSync(${JSON.stringify(sidePath)}, JSON.stringify(msg.params));
+      const response = JSON.stringify({
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: { capabilities: { diagnosticProvider: true } },
+      });
+      const out = 'Content-Length: ' + Buffer.byteLength(response) + '\\r\\n\\r\\n' + response;
+      process.stdout.write(out);
+      const notif = JSON.stringify({ jsonrpc: '2.0', method: 'initialized', params: {} });
+      const outN = 'Content-Length: ' + Buffer.byteLength(notif) + '\\r\\n\\r\\n' + notif;
+      process.stdout.write(outN);
+    }
+  }
+});
+`;
+    await writeFile(scriptPath, script);
+
+    const config: LSPServerConfig = {
+      extensions: ['ts'],
+      command: ['node', scriptPath],
+      rootDir: TEST_DIR,
+    };
+
+    await manager.getServer(config);
+
+    // Wait for side-channel file to be written.
+    let raw = '';
+    for (let i = 0; i < 50 && raw.length === 0; i++) {
+      try {
+        raw = await Bun.file(sidePath).text();
+      } catch {
+        // File may not exist yet.
+      }
+      if (!raw) await new Promise((resolve) => setTimeout(resolve, 20));
+    }
+
+    const params = JSON.parse(raw) as {
+      capabilities: {
+        textDocument: {
+          diagnostic?: { dynamicRegistration?: boolean; relatedDocumentSupport?: boolean };
+        };
+        workspace: { diagnostics?: { refreshSupport: boolean } };
+      };
+    };
+
+    expect(params.capabilities.workspace.diagnostics).toEqual({ refreshSupport: false });
+    expect(params.capabilities.textDocument.diagnostic).toEqual({
+      dynamicRegistration: false,
+      relatedDocumentSupport: false,
+    });
+  });
+});

--- a/src/lsp/server-manager.deferred-restart.test.ts
+++ b/src/lsp/server-manager.deferred-restart.test.ts
@@ -62,8 +62,8 @@ describe('ServerManager deferred restart', () => {
     manager = new ServerManager();
   });
 
-  afterEach(() => {
-    manager.dispose();
+  afterEach(async () => {
+    await manager.dispose();
     rmSync(TEST_DIR, { recursive: true, force: true });
   });
 

--- a/src/lsp/server-manager.deferred-restart.test.ts
+++ b/src/lsp/server-manager.deferred-restart.test.ts
@@ -1,0 +1,142 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { ServerManager } from './server-manager.js';
+import type { LSPServerConfig, ServerState } from './types.js';
+
+/** Write a file using Bun.write to avoid node:fs mock interference. */
+async function writeFile(path: string, content: string): Promise<void> {
+  await Bun.write(path, content);
+}
+
+/** A trivial LSP mock that just answers `initialize`. */
+const MOCK_SERVER = `
+let buf = '';
+process.stdin.on('data', (chunk) => {
+  buf += chunk.toString();
+  while (true) {
+    const idx = buf.indexOf('\\r\\n\\r\\n');
+    if (idx < 0) return;
+    const header = buf.slice(0, idx);
+    const m = header.match(/Content-Length: (\\d+)/);
+    if (!m) { buf = buf.slice(idx + 4); continue; }
+    const len = parseInt(m[1], 10);
+    const start = idx + 4;
+    if (buf.length < start + len) return;
+    const body = buf.slice(start, start + len);
+    buf = buf.slice(start + len);
+    let msg;
+    try { msg = JSON.parse(body); } catch { continue; }
+    if (msg.method === 'initialize') {
+      const response = JSON.stringify({
+        jsonrpc: '2.0',
+        id: msg.id,
+        result: { capabilities: { diagnosticProvider: true } },
+      });
+      const out = 'Content-Length: ' + Buffer.byteLength(response) + '\\r\\n\\r\\n' + response;
+      process.stdout.write(out);
+      const notif = JSON.stringify({ jsonrpc: '2.0', method: 'initialized', params: {} });
+      const outN = 'Content-Length: ' + Buffer.byteLength(notif) + '\\r\\n\\r\\n' + notif;
+      process.stdout.write(outN);
+    }
+  }
+});
+process.stdin.on('end', () => process.exit(0));
+`;
+
+/** Cast helper to access the private restartServer method. */
+interface RestartableManager {
+  restartServer(serverState: ServerState): Promise<void>;
+}
+
+describe('ServerManager deferred restart', () => {
+  let TEST_DIR: string;
+  let manager: ServerManager;
+  let scriptPath: string;
+
+  beforeEach(async () => {
+    TEST_DIR = mkdtempSync(join(tmpdir(), 'cclsp-srvmgr-restart-'));
+    scriptPath = join(TEST_DIR, 'mock-server.cjs');
+    await writeFile(scriptPath, MOCK_SERVER);
+    manager = new ServerManager();
+  });
+
+  afterEach(() => {
+    manager.dispose();
+    rmSync(TEST_DIR, { recursive: true, force: true });
+  });
+
+  function configFor(): LSPServerConfig {
+    return {
+      extensions: ['ts'],
+      command: ['node', scriptPath],
+      rootDir: TEST_DIR,
+    };
+  }
+
+  it('defers the restart when inFlightBatchCount > 0', async () => {
+    const config = configFor();
+    const state = await manager.getServer(config);
+    const originalPid = state.process.pid;
+    expect(originalPid).toBeDefined();
+
+    state.inFlightBatchCount = 1;
+
+    await (manager as unknown as RestartableManager).restartServer(state);
+
+    // Process should not have been killed; restart timer should be re-armed.
+    expect(state.process.pid).toBe(originalPid as number);
+    expect(state.process.killed).toBe(false);
+    expect(state.restartTimer).toBeDefined();
+
+    // Clean up the re-armed timer to avoid leaking it.
+    if (state.restartTimer) {
+      clearTimeout(state.restartTimer);
+      state.restartTimer = undefined;
+    }
+  });
+
+  it('proceeds with restart when inFlightBatchCount = 0', async () => {
+    const config = configFor();
+    const state = await manager.getServer(config);
+    const originalPid = state.process.pid;
+
+    expect(state.inFlightBatchCount).toBe(0);
+
+    await (manager as unknown as RestartableManager).restartServer(state);
+
+    // The old process should be gone and a new one started in its place.
+    // (The map now has a fresh ServerState; the original process has been killed.)
+    const running = manager.getRunningServers();
+    const key = JSON.stringify(config);
+    const newState = running.get(key);
+    expect(newState).toBeDefined();
+    expect(newState).not.toBe(state);
+    // The original process should have been signaled to exit.
+    expect(state.process.killed).toBe(true);
+    expect(originalPid).toBeDefined();
+    expect(newState?.process.pid).not.toBe(originalPid);
+  });
+
+  it('decrement of inFlightBatchCount in finally still allows restart', async () => {
+    const config = configFor();
+    const state = await manager.getServer(config);
+
+    // Simulate a batch that throws but cleans up the counter in finally.
+    try {
+      state.inFlightBatchCount = (state.inFlightBatchCount ?? 0) + 1;
+      throw new Error('simulated bucket failure');
+    } catch {
+      // ignore
+    } finally {
+      state.inFlightBatchCount = (state.inFlightBatchCount ?? 0) - 1;
+    }
+    expect(state.inFlightBatchCount).toBe(0);
+
+    // Now a restart should proceed.
+    await (manager as unknown as RestartableManager).restartServer(state);
+
+    expect(state.process.killed).toBe(true);
+  });
+});

--- a/src/lsp/server-manager.ts
+++ b/src/lsp/server-manager.ts
@@ -15,6 +15,20 @@ import type {
   ServerState,
 } from './types.js';
 
+function waitForProcessExit(childProcess: ChildProcess): Promise<void> {
+  if (childProcess.exitCode !== null || childProcess.signalCode !== null) {
+    return Promise.resolve();
+  }
+
+  return new Promise((resolve) => {
+    const timeout = setTimeout(resolve, 1000);
+    childProcess.once('exit', () => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+}
+
 /**
  * Manages LSP server process lifecycles.
  *
@@ -84,14 +98,20 @@ export class ServerManager {
   /**
    * Terminate all running servers and clean up resources.
    */
-  dispose(): void {
+  async dispose(): Promise<void> {
+    const exitPromises: Promise<void>[] = [];
+
     for (const serverState of this.servers.values()) {
       if (serverState.restartTimer) {
         clearTimeout(serverState.restartTimer);
       }
+
+      exitPromises.push(waitForProcessExit(serverState.process));
       serverState.process.kill();
     }
     this.servers.clear();
+
+    await Promise.all(exitPromises);
   }
 
   private isPylspServer(serverConfig: LSPServerConfig): boolean {

--- a/src/lsp/server-manager.ts
+++ b/src/lsp/server-manager.ts
@@ -11,6 +11,7 @@ import type {
   InitializeParams,
   LSPMessage,
   LSPServerConfig,
+  ServerCapabilities,
   ServerState,
 } from './types.js';
 
@@ -139,6 +140,7 @@ export class ServerManager {
       restartTimer: undefined,
       diagnosticsCache,
       adapter,
+      inFlightBatchCount: 0,
     };
 
     // Store the resolve function to call when initialized notification is received
@@ -226,6 +228,9 @@ export class ServerManager {
             documentChanges: true,
           },
           workspaceFolders: true,
+          diagnostics: {
+            refreshSupport: false,
+          },
         },
       },
       rootUri: pathToUri(serverConfig.rootDir || process.cwd()),
@@ -269,6 +274,25 @@ export class ServerManager {
       : initializeParams;
 
     const initResult = await transport.sendRequest('initialize', finalParams);
+
+    // Capture server capabilities from the initialize response. We only
+    // consume the diagnostic-related fields; ServerCapabilities intentionally
+    // does not model the full LSP capability surface. Validate the inbound
+    // shape strictly so a server returning `{}`, `null`, or
+    // `{ capabilities: null }` leaves `serverState.capabilities` undefined.
+    const initRes = initResult as unknown;
+    if (
+      initRes &&
+      typeof initRes === 'object' &&
+      'capabilities' in initRes &&
+      (initRes as { capabilities: unknown }).capabilities &&
+      typeof (initRes as { capabilities: unknown }).capabilities === 'object'
+    ) {
+      serverState.capabilities = (initRes as { capabilities: ServerCapabilities }).capabilities;
+    }
+    logger.debug(
+      `[DEBUG startServer] Captured capabilities: diagnosticProvider=${JSON.stringify(serverState.capabilities?.diagnosticProvider)}\n`
+    );
 
     // Send the initialized notification after receiving the initialize response
     transport.sendNotification('initialized', {});
@@ -381,6 +405,25 @@ export class ServerManager {
 
   private async restartServer(serverState: ServerState): Promise<void> {
     const key = JSON.stringify(serverState.config);
+
+    // Defer restart while batch diagnostics work is in progress. Re-arm the
+    // restart timer for 5 seconds so we re-check shortly. The batch path is
+    // responsible for keeping this counter accurate via try/finally. The
+    // field is optional on `ServerState` so mocks may omit it; default to 0.
+    const inFlight = serverState.inFlightBatchCount ?? 0;
+    if (inFlight > 0) {
+      logger.debug(
+        `[DEBUG restartServer] Deferring restart for ${serverState.config.command.join(' ')}: ${inFlight} batch(es) in flight\n`
+      );
+      if (serverState.restartTimer) {
+        clearTimeout(serverState.restartTimer);
+      }
+      serverState.restartTimer = setTimeout(() => {
+        this.restartServer(serverState);
+      }, 5000);
+      return;
+    }
+
     logger.info(
       `[DEBUG restartServer] Restarting LSP server for ${serverState.config.command.join(' ')}\n`
     );

--- a/src/lsp/types.ts
+++ b/src/lsp/types.ts
@@ -59,9 +59,14 @@ export interface ServerState {
     sendMessage(message: LSPMessage): void;
     sendNotification(method: string, params: unknown): void;
     rejectAllPending(reason: string): void;
+    cancelRequest?(id: number): void;
+    registerProgressHandler?(token: string | number, handler: (value: unknown) => void): void;
+    unregisterProgressHandler?(token: string | number): void;
   };
   documentManager: {
     ensureOpen(filePath: string): Promise<boolean>;
+    ensureOpenAsync?(filePath: string): Promise<boolean>;
+    closeDocument?(filePath: string): void;
     sendChange(filePath: string, text: string): void;
     isOpen(filePath: string): boolean;
     getVersion(filePath: string): number;
@@ -83,8 +88,95 @@ export interface ServerState {
         checkInterval?: number;
       }
     ): Promise<void>;
+    setResultId?(uri: string, resultId: string): void;
+    getResultId?(uri: string): string | undefined;
   };
   adapter?: ServerAdapter;
+  /**
+   * LSP server capabilities captured from the `initialize` response.
+   * Only diagnostic-related fields are typed; the rest of the LSP
+   * capability surface is intentionally not modeled here.
+   */
+  capabilities?: ServerCapabilities;
+  /**
+   * Counter of in-flight batch operations against this server. Used by
+   * `ServerManager.restartServer` to defer scheduled restarts while
+   * batch diagnostics work is in progress. Default 0.
+   *
+   * Optional so partial-`ServerState` mock literals in tests don't need to
+   * initialize it; all read-sites must use `(state.inFlightBatchCount ?? 0)`
+   * so PR2 increments never observe `NaN`.
+   */
+  inFlightBatchCount?: number;
+}
+
+// --- Diagnostic-related types (LSP 3.17) -----------------------------------
+
+/**
+ * Server-side `DiagnosticOptions` capability (LSP 3.17).
+ */
+export interface DiagnosticOptions {
+  identifier?: string;
+  interFileDependencies: boolean;
+  workspaceDiagnostics: boolean;
+}
+
+/**
+ * Subset of `ServerCapabilities` that cclsp consumes. Only the
+ * diagnostic-related fields are typed.
+ */
+export interface ServerCapabilities {
+  diagnosticProvider?: DiagnosticOptions | boolean;
+}
+
+/**
+ * Entry passed in `workspace/diagnostic`'s `previousResultIds` array.
+ */
+export interface PreviousResultId {
+  uri: string;
+  value: string;
+}
+
+/**
+ * Params for the `workspace/diagnostic` LSP request.
+ */
+export interface WorkspaceDiagnosticParams {
+  identifier?: string;
+  previousResultIds: PreviousResultId[];
+  partialResultToken?: string | number;
+  workDoneToken?: string | number;
+}
+
+export interface WorkspaceFullDocumentDiagnosticReport {
+  uri: string;
+  version: number | null;
+  kind: 'full';
+  resultId?: string;
+  items: Diagnostic[];
+}
+
+export interface WorkspaceUnchangedDocumentDiagnosticReport {
+  uri: string;
+  version: number | null;
+  kind: 'unchanged';
+  resultId: string;
+}
+
+export type WorkspaceDocumentDiagnosticReport =
+  | WorkspaceFullDocumentDiagnosticReport
+  | WorkspaceUnchangedDocumentDiagnosticReport;
+
+export interface WorkspaceDiagnosticReport {
+  items: WorkspaceDocumentDiagnosticReport[];
+}
+
+export interface WorkspaceDiagnosticReportPartialResult {
+  items: WorkspaceDocumentDiagnosticReport[];
+}
+
+export interface ProgressParams<T = unknown> {
+  token: string | number;
+  value: T;
 }
 
 /**

--- a/src/lsp/types.ts
+++ b/src/lsp/types.ts
@@ -56,6 +56,11 @@ export interface ServerState {
   process: ChildProcess;
   transport: {
     sendRequest(method: string, params: unknown, timeout?: number): Promise<unknown>;
+    sendCancellableRequest?(
+      method: string,
+      params: unknown,
+      timeout?: number
+    ): { id: number; promise: Promise<unknown> };
     sendMessage(message: LSPMessage): void;
     sendNotification(method: string, params: unknown): void;
     rejectAllPending(reason: string): void;
@@ -70,6 +75,12 @@ export interface ServerState {
     sendChange(filePath: string, text: string): void;
     isOpen(filePath: string): boolean;
     getVersion(filePath: string): number;
+    /**
+     * Snapshot of currently-open file paths. Order is undefined. Optional so
+     * partial-`ServerState` mock literals in tests don't need to provide it;
+     * the batch path treats absence as "no files open".
+     */
+    listOpen?(): string[];
   };
   initialized: boolean;
   initializationPromise: Promise<void>;
@@ -86,6 +97,7 @@ export interface ServerState {
         maxWaitTime?: number;
         idleTime?: number;
         checkInterval?: number;
+        signal?: AbortSignal;
       }
     ): Promise<void>;
     setResultId?(uri: string, resultId: string): void;
@@ -177,6 +189,117 @@ export interface WorkspaceDiagnosticReportPartialResult {
 export interface ProgressParams<T = unknown> {
   token: string | number;
   value: T;
+}
+
+// --- PR2 batch operation result types -------------------------------------
+
+/**
+ * Reason a partial result was returned. Maps 1:1 to the cap-hit header
+ * variants in the plan ("BUDGET", "MAX_FILES", "MAX_DIAGNOSTICS",
+ * "MAX_BYTES", "SERVER_CRASH").
+ */
+export type PartialReason =
+  | 'BUDGET'
+  | 'MAX_FILES'
+  | 'MAX_DIAGNOSTICS'
+  | 'MAX_BYTES'
+  | 'SERVER_CRASH';
+
+/**
+ * Counts of files dropped at the resolution/scan stage. Tools surface
+ * these in the rendered header.
+ */
+export interface DroppedCounts {
+  gitignored: number;
+  notMatched: number;
+  escaped: number;
+  unreadable: number;
+  maxFiles: number;
+  /** Files dropped because the budget elapsed before we could request them. */
+  budget?: number;
+  /** Files dropped because no LSP server matched their extension. */
+  noServer?: number;
+  /** Files dropped because their server-bucket crashed mid-batch. */
+  serverCrash?: number;
+  /** Files dropped because `include_unopened=false` and they weren't open. */
+  notOpen?: number;
+}
+
+/**
+ * Per-URI diagnostics item bundle returned by batch ops.
+ */
+export interface DiagnosticsByFile {
+  uri: string;
+  items: Diagnostic[];
+}
+
+/**
+ * Output of the `workspaceDiagnostic` op (single-bucket).
+ */
+export interface WorkspaceDiagnosticOpResult {
+  items: DiagnosticsByFile[];
+  partial?: boolean;
+  partialReason?: PartialReason;
+  droppedCounts?: Partial<DroppedCounts>;
+}
+
+/**
+ * Output of `perFilePullBatch` and `pushFallbackBatch`.
+ */
+export interface PerFileBatchResult {
+  items: DiagnosticsByFile[];
+  partial?: boolean;
+  partialReason?: PartialReason;
+  droppedCounts?: Partial<DroppedCounts>;
+}
+
+/**
+ * Input to `LSPClient.getDiagnosticsBatch`.
+ *
+ * If both `paths` and `patterns` are absent/empty the call falls back to
+ * workspace scope (workspace/diagnostic when supported by every bucket,
+ * otherwise the per-file pull path against open files).
+ */
+export interface BatchDiagnosticsRequest {
+  paths?: string[];
+  patterns?: string[];
+  root?: string;
+  respectGitignore?: boolean;
+  includeUnopened?: boolean;
+  minSeverity?: 'error' | 'warning' | 'information' | 'hint';
+  sources?: string[];
+  excludeCodes?: string[];
+  maxFiles?: number;
+  maxDiagnostics?: number;
+  maxBytes?: number;
+  timeBudgetMs?: number;
+  format?: 'summary' | 'by_file' | 'flat' | 'json';
+  groupBy?: 'file' | 'code' | 'source' | 'severity';
+}
+
+/**
+ * Output of `LSPClient.getDiagnosticsBatch` -- the tool layer renders this.
+ */
+export interface BatchDiagnosticsResult {
+  items: DiagnosticsByFile[];
+  buckets: Array<{
+    serverKey: string;
+    completed: boolean;
+    partialReason?: PartialReason;
+    fileCount: number;
+  }>;
+  filesConsidered: number;
+  filesWithDiagnostics: number;
+  scope: 'workspace' | 'paths' | 'patterns' | 'paths+patterns';
+  rootDir: string;
+  partial: boolean;
+  partialReasons: PartialReason[];
+  droppedCounts: DroppedCounts;
+  resolvedRoot: string;
+  /** Server-key strings for buckets that fully completed. */
+  completedBucketKeys: string[];
+  /** Server-key strings for buckets that finished partially. */
+  partialBucketKeys: string[];
 }
 
 /**

--- a/src/lsp/types.ts
+++ b/src/lsp/types.ts
@@ -102,6 +102,13 @@ export interface ServerState {
     ): Promise<void>;
     setResultId?(uri: string, resultId: string): void;
     getResultId?(uri: string): string | undefined;
+    /**
+     * Snapshot of `(uri, value)` pairs for every URI that has a cached
+     * `resultId`. Used by `workspaceDiagnostic` (PR3) to populate the LSP
+     * `previousResultIds` array on subsequent calls so the server can
+     * answer with `kind: 'unchanged'` reports.
+     */
+    listResultIds?(): Array<{ uri: string; value: string }>;
   };
   adapter?: ServerAdapter;
   /**

--- a/src/tools/diagnostics-format.test.ts
+++ b/src/tools/diagnostics-format.test.ts
@@ -1,0 +1,402 @@
+import { describe, expect, it } from 'bun:test';
+import type { Diagnostic, DiagnosticsByFile } from '../lsp/types.js';
+import { clipMessage, filterDiagnostics, renderBatch, renderHeader } from './diagnostics-format.js';
+
+function mkDiag(opts: Partial<Diagnostic> = {}): Diagnostic {
+  return {
+    range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+    severity: 1,
+    message: 'oops',
+    source: 'mock',
+    code: 'E001',
+    ...opts,
+  };
+}
+
+function mkFile(uri: string, items: Diagnostic[]): DiagnosticsByFile {
+  return { uri, items };
+}
+
+describe('filterDiagnostics', () => {
+  it('drops diagnostics below min_severity', () => {
+    const items = [
+      mkFile('file:///a.ts', [
+        mkDiag({ severity: 1, message: 'err' }),
+        mkDiag({ severity: 2, message: 'warn' }),
+        mkDiag({ severity: 3, message: 'info' }),
+        mkDiag({ severity: 4, message: 'hint' }),
+      ]),
+    ];
+    const res = filterDiagnostics(items, {
+      minSeverity: 'warning',
+      maxDiagnostics: 100,
+    });
+    const msgs = res.filtered.flatMap((f) => f.items.map((d) => d.message));
+    expect(msgs).toEqual(['err', 'warn']);
+    expect(res.counts.errors).toBe(1);
+    expect(res.counts.warnings).toBe(1);
+  });
+
+  it('honors sources whitelist', () => {
+    const items = [
+      mkFile('file:///a.ts', [
+        mkDiag({ source: 'typescript', severity: 1 }),
+        mkDiag({ source: 'eslint', severity: 1 }),
+        mkDiag({ source: undefined, severity: 1 }),
+      ]),
+    ];
+    const res = filterDiagnostics(items, {
+      minSeverity: 'hint',
+      sources: ['typescript'],
+      maxDiagnostics: 100,
+    });
+    expect(res.filtered[0]?.items).toHaveLength(1);
+    expect(res.filtered[0]?.items[0]?.source).toBe('typescript');
+  });
+
+  it('honors exclude_codes blacklist', () => {
+    const items = [
+      mkFile('file:///a.ts', [
+        mkDiag({ code: 'E001', severity: 1 }),
+        mkDiag({ code: 'E002', severity: 1 }),
+      ]),
+    ];
+    const res = filterDiagnostics(items, {
+      minSeverity: 'hint',
+      excludeCodes: ['E001'],
+      maxDiagnostics: 100,
+    });
+    expect(res.filtered[0]?.items).toHaveLength(1);
+    expect(res.filtered[0]?.items[0]?.code).toBe('E002');
+  });
+
+  it('truncates highest-severity-first when above max_diagnostics', () => {
+    const items = [
+      mkFile('file:///a.ts', [
+        mkDiag({ severity: 4, message: 'h1' }),
+        mkDiag({ severity: 2, message: 'w1' }),
+        mkDiag({ severity: 1, message: 'e1' }),
+        mkDiag({ severity: 1, message: 'e2' }),
+        mkDiag({ severity: 3, message: 'i1' }),
+      ]),
+    ];
+    const res = filterDiagnostics(items, {
+      minSeverity: 'hint',
+      maxDiagnostics: 2,
+    });
+    expect(res.counts.truncatedBy).toBe('MAX_DIAGNOSTICS');
+    expect(res.counts.totalAfter).toBe(2);
+    const msgs = res.filtered.flatMap((f) => f.items.map((d) => d.message));
+    // Both errors should win (severity 1).
+    expect(msgs.sort()).toEqual(['e1', 'e2']);
+  });
+
+  it('truncation is deterministic across runs', () => {
+    const items = [
+      mkFile('file:///b.ts', [
+        mkDiag({ severity: 1, message: 'b-e1' }),
+        mkDiag({ severity: 2, message: 'b-w1' }),
+      ]),
+      mkFile('file:///a.ts', [
+        mkDiag({ severity: 1, message: 'a-e1' }),
+        mkDiag({ severity: 2, message: 'a-w1' }),
+      ]),
+    ];
+    const r1 = filterDiagnostics(items, { minSeverity: 'hint', maxDiagnostics: 2 });
+    const r2 = filterDiagnostics(items, { minSeverity: 'hint', maxDiagnostics: 2 });
+    const flat1 = r1.filtered.flatMap((f) => f.items.map((d) => d.message)).join(',');
+    const flat2 = r2.filtered.flatMap((f) => f.items.map((d) => d.message)).join(',');
+    expect(flat1).toBe(flat2);
+  });
+});
+
+describe('clipMessage', () => {
+  it('returns original when within 240 chars', () => {
+    const { text, originalLen } = clipMessage('short');
+    expect(text).toBe('short');
+    expect(originalLen).toBe(5);
+  });
+
+  it('clips messages > 240 chars to 239 + ellipsis', () => {
+    const msg = 'x'.repeat(300);
+    const { text, originalLen } = clipMessage(msg);
+    expect(originalLen).toBe(300);
+    expect(text.length).toBe(240);
+    expect(text.endsWith('…')).toBe(true);
+  });
+});
+
+describe('renderBatch formats', () => {
+  const fixture = [
+    mkFile('file:///a.ts', [
+      mkDiag({ severity: 1, message: 'err-a', code: 'E1' }),
+      mkDiag({ severity: 2, message: 'warn-a', code: 'W1' }),
+    ]),
+    mkFile('file:///b.ts', [mkDiag({ severity: 1, message: 'err-b', code: 'E2' })]),
+  ];
+
+  it('by_file format includes per-file headers and bullets', () => {
+    const r = renderBatch(fixture, {
+      format: 'by_file',
+      groupBy: 'file',
+      maxBytes: 100000,
+      header: 'HEADER',
+    });
+    expect(r.text).toContain('a.ts');
+    expect(r.text).toContain('b.ts');
+    expect(r.text).toContain('•');
+    expect(r.text).toContain('err-a');
+    expect(r.text).toContain('warn-a');
+    expect(r.text).toContain('err-b');
+  });
+
+  it('summary format lists files and counts', () => {
+    const r = renderBatch(fixture, {
+      format: 'summary',
+      groupBy: 'file',
+      maxBytes: 100000,
+      header: 'HEADER',
+    });
+    expect(r.text).toContain('Summary');
+    expect(r.text).toMatch(/a\.ts/);
+    expect(r.text).toMatch(/→ 2/);
+  });
+
+  it('flat format includes messageLen annotation', () => {
+    const r = renderBatch(fixture, {
+      format: 'flat',
+      groupBy: 'file',
+      maxBytes: 100000,
+      header: 'HEADER',
+    });
+    expect(r.text).toContain('messageLen:');
+  });
+
+  it('json format produces a fenced JSON block', () => {
+    const r = renderBatch(fixture, {
+      format: 'json',
+      groupBy: 'file',
+      maxBytes: 100000,
+      header: 'HEADER',
+    });
+    expect(r.text).toContain('```json');
+    expect(r.text).toContain('```');
+  });
+
+  it('by_file auto-falls back to summary when projected size > max_bytes', () => {
+    // Build a fixture that is genuinely large in by_file form.
+    const big: DiagnosticsByFile[] = [];
+    for (let f = 0; f < 50; f++) {
+      const items: Diagnostic[] = [];
+      for (let i = 0; i < 20; i++) {
+        items.push(
+          mkDiag({
+            severity: 1,
+            message: `lorem ipsum dolor sit amet ${i}`,
+            code: `C${i}`,
+          })
+        );
+      }
+      big.push(mkFile(`file:///f${f}.ts`, items));
+    }
+    const r = renderBatch(big, {
+      format: 'by_file',
+      groupBy: 'file',
+      maxBytes: 1500,
+      header: 'HEADER',
+    });
+    expect(r.autoFallback).toBe('by_file_to_summary');
+  });
+
+  it('hard-truncates output when over max_bytes', () => {
+    const items: Diagnostic[] = [];
+    for (let i = 0; i < 100; i++) {
+      items.push(mkDiag({ message: `lorem ipsum dolor sit amet ${i}` }));
+    }
+    const r = renderBatch([mkFile('file:///a.ts', items)], {
+      format: 'flat',
+      groupBy: 'file',
+      maxBytes: 500,
+      header: 'HEADER',
+    });
+    expect(Buffer.byteLength(r.text)).toBeLessThanOrEqual(500);
+    expect(r.text).toContain('output truncated');
+  });
+});
+
+describe('renderHeader', () => {
+  it('renders OK status with severity counts and caps', () => {
+    const counts = {
+      errors: 3,
+      warnings: 5,
+      info: 0,
+      hints: 0,
+      totalBefore: 8,
+      totalAfter: 8,
+      topSources: [{ source: 'typescript', count: 8 }],
+      topCodes: [],
+    };
+    const header = renderHeader({
+      status: 'OK',
+      scope: 'workspace',
+      root: '/repo',
+      bucketCount: 1,
+      filesConsidered: 10,
+      filesWithDiagnostics: 4,
+      counts,
+      caps: { max_files: 1000, max_diagnostics: 500, max_bytes: 32768, time_budget_ms: 30000 },
+      filters: { min_severity: 'warning' },
+    });
+    expect(header).toContain('get_workspace_diagnostics — OK');
+    expect(header).toContain('Scope: workspace  Root: /repo');
+    expect(header).toContain('Severity counts: errors=3, warnings=5');
+    expect(header).toContain('Top sources: typescript:8');
+    expect(header).toContain('Caps: max_files=1000');
+  });
+
+  it('renders BUDGET banner when partial', () => {
+    const counts = {
+      errors: 0,
+      warnings: 0,
+      info: 0,
+      hints: 0,
+      totalBefore: 0,
+      totalAfter: 0,
+      topSources: [],
+      topCodes: [],
+    };
+    const header = renderHeader({
+      status: 'PARTIAL',
+      scope: 'workspace',
+      root: '/repo',
+      bucketCount: 1,
+      filesConsidered: 0,
+      filesWithDiagnostics: 0,
+      counts,
+      caps: { max_files: 1000, max_diagnostics: 500, max_bytes: 32768, time_budget_ms: 30000 },
+      filters: { min_severity: 'warning' },
+      partialReasons: ['BUDGET'],
+      budgetMs: 30000,
+      resultsCollected: 0,
+    });
+    expect(header).toContain('Wall-clock budget exhausted (BUDGET): 30000 ms');
+    expect(header).toContain('0 results collected');
+  });
+
+  it('renders MAX_FILES banner', () => {
+    const counts = {
+      errors: 0,
+      warnings: 0,
+      info: 0,
+      hints: 0,
+      totalBefore: 0,
+      totalAfter: 0,
+      topSources: [],
+      topCodes: [],
+    };
+    const header = renderHeader({
+      status: 'PARTIAL',
+      scope: 'patterns',
+      root: '/repo',
+      bucketCount: 1,
+      filesConsidered: 1000,
+      filesWithDiagnostics: 0,
+      counts,
+      caps: { max_files: 1000, max_diagnostics: 500, max_bytes: 32768, time_budget_ms: 30000 },
+      filters: { min_severity: 'warning' },
+      partialReasons: ['MAX_FILES'],
+      droppedCounts: {
+        gitignored: 0,
+        notMatched: 0,
+        escaped: 0,
+        unreadable: 0,
+        maxFiles: 3823,
+      },
+    });
+    expect(header).toContain('File cap hit (MAX_FILES)');
+    expect(header).toContain('truncated input from 4823 to 1000');
+  });
+
+  it('renders MAX_DIAGNOSTICS banner', () => {
+    const counts = {
+      errors: 500,
+      warnings: 0,
+      info: 0,
+      hints: 0,
+      totalBefore: 1247,
+      totalAfter: 500,
+      topSources: [],
+      topCodes: [],
+      truncatedBy: 'MAX_DIAGNOSTICS' as const,
+    };
+    const header = renderHeader({
+      status: 'PARTIAL',
+      scope: 'workspace',
+      root: '/repo',
+      bucketCount: 1,
+      filesConsidered: 50,
+      filesWithDiagnostics: 25,
+      counts,
+      caps: { max_files: 1000, max_diagnostics: 500, max_bytes: 32768, time_budget_ms: 30000 },
+      filters: { min_severity: 'warning' },
+      partialReasons: ['MAX_DIAGNOSTICS'],
+    });
+    expect(header).toContain('Diagnostic cap hit (MAX_DIAGNOSTICS): 500/1247');
+  });
+
+  it('renders MAX_BYTES banner', () => {
+    const counts = {
+      errors: 0,
+      warnings: 0,
+      info: 0,
+      hints: 0,
+      totalBefore: 0,
+      totalAfter: 0,
+      topSources: [],
+      topCodes: [],
+    };
+    const header = renderHeader({
+      status: 'PARTIAL',
+      scope: 'workspace',
+      root: '/repo',
+      bucketCount: 1,
+      filesConsidered: 0,
+      filesWithDiagnostics: 0,
+      counts,
+      caps: { max_files: 1000, max_diagnostics: 500, max_bytes: 32768, time_budget_ms: 30000 },
+      filters: { min_severity: 'warning' },
+      partialReasons: ['MAX_BYTES'],
+      autoFallback: 'by_file_to_summary',
+    });
+    expect(header).toContain('Output size cap hit (MAX_BYTES)');
+    expect(header).toContain('Auto-fallback: by_file → summary');
+  });
+
+  it('renders SERVER_CRASH banner', () => {
+    const counts = {
+      errors: 0,
+      warnings: 0,
+      info: 0,
+      hints: 0,
+      totalBefore: 0,
+      totalAfter: 0,
+      topSources: [],
+      topCodes: [],
+    };
+    const header = renderHeader({
+      status: 'PARTIAL',
+      scope: 'workspace',
+      root: '/repo',
+      bucketCount: 2,
+      filesConsidered: 10,
+      filesWithDiagnostics: 5,
+      counts,
+      caps: { max_files: 1000, max_diagnostics: 500, max_bytes: 32768, time_budget_ms: 30000 },
+      filters: { min_severity: 'warning' },
+      partialReasons: ['SERVER_CRASH'],
+      partialBuckets: ['pylsp@/repo'],
+    });
+    expect(header).toContain('Server crash (SERVER_CRASH)');
+    expect(header).toContain('pylsp@/repo');
+  });
+});

--- a/src/tools/diagnostics-format.test.ts
+++ b/src/tools/diagnostics-format.test.ts
@@ -221,6 +221,24 @@ describe('renderBatch formats', () => {
     });
     expect(Buffer.byteLength(r.text)).toBeLessThanOrEqual(500);
     expect(r.text).toContain('output truncated');
+    expect(r.hardTruncated).toBe(true);
+  });
+
+  it('hard-truncates json without deleting the surviving payload', () => {
+    const items: Diagnostic[] = [];
+    for (let i = 0; i < 100; i++) {
+      items.push(mkDiag({ message: `lorem ipsum dolor sit amet ${i}` }));
+    }
+    const r = renderBatch([mkFile('file:///a.ts', items)], {
+      format: 'json',
+      groupBy: 'file',
+      maxBytes: 500,
+      header: 'HEADER',
+    });
+    expect(r.text).toContain('```json');
+    expect(r.text).toContain('file:///a.ts');
+    expect(r.text).not.toContain('/* truncated */');
+    expect(r.hardTruncated).toBe(true);
   });
 });
 

--- a/src/tools/diagnostics-format.ts
+++ b/src/tools/diagnostics-format.ts
@@ -1,0 +1,555 @@
+import type { Diagnostic, DiagnosticsByFile, DroppedCounts, PartialReason } from '../lsp/types.js';
+import { uriToPath } from '../utils.js';
+
+/**
+ * Severity label table. Mirrors the existing single-file tool.
+ */
+const SEVERITY_NAME: Record<number, string> = {
+  1: 'Error',
+  2: 'Warning',
+  3: 'Information',
+  4: 'Hint',
+};
+
+const SEVERITY_RANK: Record<string, number> = {
+  error: 1,
+  warning: 2,
+  information: 3,
+  hint: 4,
+};
+
+const PER_FILE_CAP = 20;
+const MESSAGE_CLIP_LIMIT = 240;
+
+export type MinSeverity = 'error' | 'warning' | 'information' | 'hint';
+export type RenderFormat = 'summary' | 'by_file' | 'flat' | 'json';
+export type GroupBy = 'file' | 'code' | 'source' | 'severity';
+
+export interface FilterOptions {
+  minSeverity: MinSeverity;
+  sources?: string[];
+  excludeCodes?: string[];
+  maxDiagnostics: number;
+}
+
+export interface FilterCounts {
+  errors: number;
+  warnings: number;
+  info: number;
+  hints: number;
+  totalBefore: number;
+  totalAfter: number;
+  /** Top diagnostic source counts (descending, ties broken alphabetically). */
+  topSources: Array<{ source: string; count: number }>;
+  /** Top diagnostic code counts. */
+  topCodes: Array<{ code: string; count: number }>;
+  /** Set when filtered output was truncated by max_diagnostics. */
+  truncatedBy?: 'MAX_DIAGNOSTICS';
+  /** Number of diagnostics dropped after applying max_diagnostics. */
+  truncatedCount?: number;
+}
+
+export interface FilterResult {
+  filtered: DiagnosticsByFile[];
+  counts: FilterCounts;
+}
+
+/**
+ * Apply min_severity / sources / exclude_codes filters, then sort
+ * highest-severity first and truncate to `maxDiagnostics`. Stable across
+ * runs given the same input.
+ */
+export function filterDiagnostics(items: DiagnosticsByFile[], opts: FilterOptions): FilterResult {
+  const minRank = SEVERITY_RANK[opts.minSeverity] ?? 4;
+  const sourcesSet = opts.sources && opts.sources.length > 0 ? new Set(opts.sources) : null;
+  const excludeSet =
+    opts.excludeCodes && opts.excludeCodes.length > 0 ? new Set(opts.excludeCodes) : null;
+
+  let totalBefore = 0;
+  let errors = 0;
+  let warnings = 0;
+  let info = 0;
+  let hints = 0;
+  const sourceCounts = new Map<string, number>();
+  const codeCounts = new Map<string, number>();
+
+  // Pass 1: filter per-file lists.
+  const filteredPerFile: DiagnosticsByFile[] = [];
+  for (const file of items) {
+    totalBefore += file.items.length;
+    const kept: Diagnostic[] = [];
+    for (const d of file.items) {
+      const sev = d.severity ?? 1;
+      if (sev > minRank) continue;
+      if (sourcesSet && (!d.source || !sourcesSet.has(d.source))) continue;
+      const codeStr = d.code !== undefined ? String(d.code) : undefined;
+      if (excludeSet && codeStr && excludeSet.has(codeStr)) continue;
+      kept.push(d);
+      if (sev === 1) errors++;
+      else if (sev === 2) warnings++;
+      else if (sev === 3) info++;
+      else hints++;
+      if (d.source) sourceCounts.set(d.source, (sourceCounts.get(d.source) ?? 0) + 1);
+      if (codeStr) codeCounts.set(codeStr, (codeCounts.get(codeStr) ?? 0) + 1);
+    }
+    if (kept.length > 0) {
+      filteredPerFile.push({ uri: file.uri, items: kept });
+    }
+  }
+
+  let totalAfter = filteredPerFile.reduce((acc, f) => acc + f.items.length, 0);
+  let truncatedBy: 'MAX_DIAGNOSTICS' | undefined;
+  let truncatedCount: number | undefined;
+
+  // Pass 2: enforce max_diagnostics globally, keeping highest-severity
+  // first. We sort a flat list, then rebuild per-file groups.
+  if (totalAfter > opts.maxDiagnostics) {
+    const flat: Array<{ uri: string; d: Diagnostic; idx: number }> = [];
+    let idx = 0;
+    for (const f of filteredPerFile) {
+      for (const d of f.items) {
+        flat.push({ uri: f.uri, d, idx: idx++ });
+      }
+    }
+    flat.sort((a, b) => {
+      const sa = a.d.severity ?? 1;
+      const sb = b.d.severity ?? 1;
+      if (sa !== sb) return sa - sb;
+      if (a.uri !== b.uri) return a.uri < b.uri ? -1 : 1;
+      const la = a.d.range.start.line;
+      const lb = b.d.range.start.line;
+      if (la !== lb) return la - lb;
+      return a.idx - b.idx;
+    });
+    const kept = flat.slice(0, opts.maxDiagnostics);
+    const keptByUri = new Map<string, Diagnostic[]>();
+    for (const k of kept) {
+      const arr = keptByUri.get(k.uri);
+      if (arr) arr.push(k.d);
+      else keptByUri.set(k.uri, [k.d]);
+    }
+    // Preserve URI ordering from the original filteredPerFile, but drop
+    // files whose diagnostics were entirely truncated.
+    const rebuilt: DiagnosticsByFile[] = [];
+    for (const f of filteredPerFile) {
+      const items = keptByUri.get(f.uri);
+      if (items && items.length > 0) {
+        rebuilt.push({ uri: f.uri, items });
+      }
+    }
+    truncatedBy = 'MAX_DIAGNOSTICS';
+    truncatedCount = totalAfter - opts.maxDiagnostics;
+    filteredPerFile.length = 0;
+    filteredPerFile.push(...rebuilt);
+    totalAfter = opts.maxDiagnostics;
+  }
+
+  const topSources = Array.from(sourceCounts.entries())
+    .sort((a, b) => (a[1] === b[1] ? a[0].localeCompare(b[0]) : b[1] - a[1]))
+    .slice(0, 5)
+    .map(([source, count]) => ({ source, count }));
+  const topCodes = Array.from(codeCounts.entries())
+    .sort((a, b) => (a[1] === b[1] ? a[0].localeCompare(b[0]) : b[1] - a[1]))
+    .slice(0, 5)
+    .map(([code, count]) => ({ code, count }));
+
+  return {
+    filtered: filteredPerFile,
+    counts: {
+      errors,
+      warnings,
+      info,
+      hints,
+      totalBefore,
+      totalAfter,
+      topSources,
+      topCodes,
+      truncatedBy,
+      truncatedCount,
+    },
+  };
+}
+
+/**
+ * Clip a diagnostic `message` to `MESSAGE_CLIP_LIMIT` characters,
+ * appending the `…` ellipsis when truncated.
+ */
+export function clipMessage(message: string): { text: string; originalLen: number } {
+  const originalLen = message.length;
+  if (originalLen <= MESSAGE_CLIP_LIMIT) return { text: message, originalLen };
+  return { text: `${message.slice(0, MESSAGE_CLIP_LIMIT - 1)}…`, originalLen };
+}
+
+export interface HeaderArgs {
+  status: 'OK' | 'PARTIAL' | 'EMPTY';
+  scope: 'workspace' | 'paths' | 'patterns' | 'paths+patterns';
+  root: string;
+  bucketCount: number;
+  filesConsidered: number;
+  filesWithDiagnostics: number;
+  counts: FilterCounts;
+  caps: {
+    max_files: number;
+    max_diagnostics: number;
+    max_bytes: number;
+    time_budget_ms: number;
+  };
+  filters: {
+    min_severity: MinSeverity;
+    sources?: string[];
+    exclude_codes?: string[];
+  };
+  partialReasons?: PartialReason[];
+  partialBuckets?: string[];
+  completedBuckets?: string[];
+  droppedCounts?: DroppedCounts;
+  autoFallback?: 'by_file_to_summary';
+  budgetMs?: number;
+  resultsCollected?: number;
+  filesCollected?: number;
+}
+
+/**
+ * Render the header block for the batch tool output. The body of the
+ * report is rendered by {@link renderBatch}.
+ */
+export function renderHeader(args: HeaderArgs): string {
+  const lines: string[] = [];
+  lines.push(`get_workspace_diagnostics — ${args.status}`);
+
+  // Cap-hit banners precede the main metadata so agents see them first.
+  if (args.partialReasons && args.partialReasons.length > 0) {
+    for (const reason of args.partialReasons) {
+      lines.push(...renderReasonBanner(reason, args));
+    }
+  }
+  if (args.autoFallback === 'by_file_to_summary') {
+    lines.push(
+      '[!] Auto-fallback: by_file → summary (would have exceeded max_bytes; rendered as summary).'
+    );
+  }
+
+  const scopeLabel = formatScopeLabel(args);
+  lines.push(`Scope: ${scopeLabel}  Root: ${args.root}`);
+  lines.push(
+    `Buckets: ${args.bucketCount} servers  Files considered: ${args.filesConsidered}  Files with diagnostics: ${args.filesWithDiagnostics}`
+  );
+  lines.push(
+    `Severity counts: errors=${args.counts.errors}, warnings=${args.counts.warnings}, info=${args.counts.info}, hints=${args.counts.hints}`
+  );
+
+  const sources =
+    args.counts.topSources.length > 0
+      ? args.counts.topSources.map((s) => `${s.source}:${s.count}`).join(', ')
+      : '(none)';
+  const codes =
+    args.counts.topCodes.length > 0
+      ? args.counts.topCodes.map((c) => `${c.code}:${c.count}`).join(', ')
+      : '(none)';
+  lines.push(`Top sources: ${sources}   Top codes: ${codes}`);
+
+  lines.push(
+    `Caps: max_files=${args.caps.max_files}, max_diagnostics=${args.caps.max_diagnostics}, max_bytes=${args.caps.max_bytes}, time_budget_ms=${args.caps.time_budget_ms}`
+  );
+
+  if (
+    args.filters.min_severity !== 'warning' ||
+    (args.filters.sources && args.filters.sources.length > 0) ||
+    (args.filters.exclude_codes && args.filters.exclude_codes.length > 0)
+  ) {
+    const parts: string[] = [`min_severity=${args.filters.min_severity}`];
+    if (args.filters.sources && args.filters.sources.length > 0) {
+      parts.push(`sources=[${args.filters.sources.join(',')}]`);
+    }
+    if (args.filters.exclude_codes && args.filters.exclude_codes.length > 0) {
+      parts.push(`exclude_codes=[${args.filters.exclude_codes.join(',')}]`);
+    }
+    lines.push(`Filters: ${parts.join(', ')}`);
+  } else {
+    lines.push(`Filters: min_severity=${args.filters.min_severity}`);
+  }
+
+  if (args.partialBuckets && args.partialBuckets.length > 0) {
+    lines.push(`Partial buckets: [${args.partialBuckets.join(', ')}]`);
+  }
+  if (args.completedBuckets && args.completedBuckets.length > 0) {
+    lines.push(`Completed buckets: [${args.completedBuckets.join(', ')}]`);
+  }
+
+  return lines.join('\n');
+}
+
+function formatScopeLabel(args: HeaderArgs): string {
+  if (args.scope === 'workspace') return 'workspace';
+  if (args.scope === 'paths') return `paths=${args.filesConsidered}`;
+  if (args.scope === 'patterns') return `patterns=${args.filesConsidered}`;
+  return `paths+patterns=${args.filesConsidered}`;
+}
+
+function renderReasonBanner(reason: PartialReason, args: HeaderArgs): string[] {
+  switch (reason) {
+    case 'BUDGET': {
+      const ms = args.budgetMs ?? args.caps.time_budget_ms;
+      const collected = args.resultsCollected ?? args.counts.totalAfter;
+      const files = args.filesCollected ?? args.filesWithDiagnostics;
+      if (collected === 0) {
+        return [
+          `[!] Wall-clock budget exhausted (BUDGET): ${ms} ms reached with 0 results collected.`,
+          '[!] Reduce scope (`paths`/`patterns`) or increase `time_budget_ms` (up to 120000). Not retried automatically.',
+        ];
+      }
+      return [
+        `[!] Wall-clock budget exhausted (BUDGET): ${ms} ms reached after collecting ${collected}/?? diagnostics across ${files}/?? files.`,
+        '[!] do NOT retry with the same args — narrow scope (use `paths` or `patterns`, or raise `time_budget_ms` up to 120000).',
+      ];
+    }
+    case 'MAX_FILES': {
+      const cap = args.caps.max_files;
+      const dropped = args.droppedCounts?.maxFiles ?? 0;
+      const total = cap + dropped;
+      return [
+        `[!] File cap hit (MAX_FILES): truncated input from ${total} to ${cap} files; remaining files not inspected.`,
+        '[!] do NOT retry with the same args — narrow scope (use a more specific `patterns` or raise `max_files`).',
+      ];
+    }
+    case 'MAX_DIAGNOSTICS': {
+      const cap = args.caps.max_diagnostics;
+      const totalBefore = args.counts.totalBefore;
+      return [
+        `[!] Diagnostic cap hit (MAX_DIAGNOSTICS): ${cap}/${totalBefore} diagnostics rendered (highest severity first).`,
+        '[!] do NOT retry with the same args — narrow scope (raise `min_severity` to `error`, or narrow `paths`).',
+      ];
+    }
+    case 'MAX_BYTES': {
+      return [
+        `[!] Output size cap hit (MAX_BYTES): rendered output would have exceeded ${args.caps.max_bytes} bytes; fell back to \`summary\` format.`,
+        '[!] do NOT retry with the same args — narrow scope (use `paths`, narrow `patterns`, or raise `min_severity`).',
+      ];
+    }
+    case 'SERVER_CRASH': {
+      const buckets =
+        args.partialBuckets && args.partialBuckets.length > 0
+          ? args.partialBuckets.join(', ')
+          : 'unknown';
+      return [`[!] Server crash (SERVER_CRASH): ${buckets} died mid-batch; its bucket is partial.`];
+    }
+    default:
+      return [];
+  }
+}
+
+/**
+ * Result of {@link renderBatch}: the rendered text plus a flag noting
+ * when an auto-fallback from `by_file` to `summary` happened.
+ */
+export interface RenderBatchResult {
+  text: string;
+  autoFallback?: 'by_file_to_summary';
+}
+
+export interface RenderBatchOptions {
+  format: RenderFormat;
+  groupBy: GroupBy;
+  maxBytes: number;
+  header: string;
+  perFileCap?: number;
+}
+
+/**
+ * Render the body of a batch diagnostics report. The header is rendered
+ * separately by {@link renderHeader}.
+ *
+ * Honors the plan's rules:
+ *   - by_file: per-file blocks, sorted by file URI, first 20 diagnostics
+ *     per file (severity asc, then line), `... +N more` rollup.
+ *   - summary: one-line totals + top sources / codes.
+ *   - flat: one line per diagnostic with `messageLen:N` annotation.
+ *   - json: fenced JSON block.
+ *   - by_file + projected size > max_bytes → falls back to summary.
+ *   - Hard truncation at max_bytes; tries to close fences cleanly.
+ */
+export function renderBatch(
+  filtered: DiagnosticsByFile[],
+  opts: RenderBatchOptions
+): RenderBatchResult {
+  const headerSize = Buffer.byteLength(opts.header);
+  const headerWithGap = `${opts.header}\n\n`;
+
+  let format = opts.format;
+  let body = renderBody(filtered, format, opts);
+  let autoFallback: 'by_file_to_summary' | undefined;
+
+  if (format === 'by_file') {
+    const projected = headerSize + Buffer.byteLength(`\n\n${body}`);
+    if (projected > opts.maxBytes) {
+      format = 'summary';
+      body = renderBody(filtered, format, opts);
+      autoFallback = 'by_file_to_summary';
+    }
+  }
+
+  let text = headerWithGap + body;
+  const finalSize = Buffer.byteLength(text);
+  if (finalSize > opts.maxBytes) {
+    text = hardTruncate(text, opts.maxBytes, format);
+  }
+
+  return autoFallback ? { text, autoFallback } : { text };
+}
+
+function renderBody(
+  filtered: DiagnosticsByFile[],
+  format: RenderFormat,
+  opts: RenderBatchOptions
+): string {
+  switch (format) {
+    case 'summary':
+      return renderSummary(filtered);
+    case 'by_file':
+      return renderByFile(filtered, opts.perFileCap ?? PER_FILE_CAP);
+    case 'flat':
+      return renderFlat(filtered);
+    case 'json':
+      return renderJson(filtered);
+    default:
+      return renderByFile(filtered, opts.perFileCap ?? PER_FILE_CAP);
+  }
+}
+
+function renderSummary(filtered: DiagnosticsByFile[]): string {
+  if (filtered.length === 0) {
+    return '(no diagnostics)';
+  }
+  const lines: string[] = ['Summary (file → diagnostic count):'];
+  for (const file of filtered) {
+    const path = safeUriToPath(file.uri);
+    lines.push(`  ${path} → ${file.items.length}`);
+  }
+  return lines.join('\n');
+}
+
+function renderByFile(filtered: DiagnosticsByFile[], perFileCap: number): string {
+  if (filtered.length === 0) return '(no diagnostics)';
+  const lines: string[] = [];
+  // Stable ordering: by URI alphabetical.
+  const sorted = [...filtered].sort((a, b) => (a.uri < b.uri ? -1 : a.uri > b.uri ? 1 : 0));
+  for (const file of sorted) {
+    const path = safeUriToPath(file.uri);
+    const counts = countSeverities(file.items);
+    lines.push(
+      `${path}  (${counts.errors} errors, ${counts.warnings} warnings, ${counts.info} info, ${counts.hints} hints)`
+    );
+    const sorted = [...file.items].sort((a, b) => {
+      const sa = a.severity ?? 1;
+      const sb = b.severity ?? 1;
+      if (sa !== sb) return sa - sb;
+      return a.range.start.line - b.range.start.line;
+    });
+    const visible = sorted.slice(0, perFileCap);
+    for (const d of visible) {
+      const sev = SEVERITY_NAME[d.severity ?? 1] ?? 'Unknown';
+      const code = d.code !== undefined ? ` [${d.code}]` : '';
+      const source = d.source ? ` (${d.source})` : '';
+      const { text } = clipMessage(d.message);
+      lines.push(`  • ${sev}${code}${source}: ${text}`);
+      const { start, end } = d.range;
+      lines.push(
+        `    Location: Line ${start.line + 1}, Column ${start.character + 1} to Line ${end.line + 1}, Column ${end.character + 1}`
+      );
+    }
+    if (sorted.length > perFileCap) {
+      const extra = sorted.length - perFileCap;
+      lines.push(`  ... +${extra} more (use min_severity=error or narrow paths)`);
+    }
+    lines.push('');
+  }
+  return lines.join('\n').trimEnd();
+}
+
+function renderFlat(filtered: DiagnosticsByFile[]): string {
+  const lines: string[] = [];
+  for (const file of filtered) {
+    const path = safeUriToPath(file.uri);
+    for (const d of file.items) {
+      const sev = SEVERITY_NAME[d.severity ?? 1] ?? 'Unknown';
+      const code = d.code !== undefined ? `[${d.code}] ` : '';
+      const source = d.source ? `(${d.source}) ` : '';
+      const { text, originalLen } = clipMessage(d.message);
+      const { start } = d.range;
+      lines.push(
+        `${path}:${start.line + 1}:${start.character + 1}  ${sev} ${code}${source}${text}  messageLen:${originalLen}`
+      );
+    }
+  }
+  return lines.length > 0 ? lines.join('\n') : '(no diagnostics)';
+}
+
+function renderJson(filtered: DiagnosticsByFile[]): string {
+  const payload = filtered.map((file) => ({
+    uri: file.uri,
+    path: safeUriToPath(file.uri),
+    items: file.items.map((d) => {
+      const { text, originalLen } = clipMessage(d.message);
+      return {
+        severity: d.severity ?? 1,
+        severityName: SEVERITY_NAME[d.severity ?? 1] ?? 'Unknown',
+        code: d.code,
+        source: d.source,
+        message: text,
+        messageLen: originalLen,
+        range: d.range,
+      };
+    }),
+  }));
+  return `\`\`\`json\n${JSON.stringify(payload, null, 2)}\n\`\`\``;
+}
+
+function countSeverities(items: Diagnostic[]): {
+  errors: number;
+  warnings: number;
+  info: number;
+  hints: number;
+} {
+  let errors = 0;
+  let warnings = 0;
+  let info = 0;
+  let hints = 0;
+  for (const d of items) {
+    const sev = d.severity ?? 1;
+    if (sev === 1) errors++;
+    else if (sev === 2) warnings++;
+    else if (sev === 3) info++;
+    else hints++;
+  }
+  return { errors, warnings, info, hints };
+}
+
+function safeUriToPath(uri: string): string {
+  try {
+    return uriToPath(uri);
+  } catch {
+    return uri;
+  }
+}
+
+/**
+ * Hard-truncate `text` to `maxBytes`. Tries to close a json fence if the
+ * cut lands inside one. Appends a one-line marker so the agent knows the
+ * output was truncated.
+ */
+function hardTruncate(text: string, maxBytes: number, format: RenderFormat): string {
+  const marker = `\n... [output truncated at max_bytes=${maxBytes}]`;
+  const markerSize = Buffer.byteLength(marker);
+  const budget = Math.max(0, maxBytes - markerSize);
+  // Walk back from `budget` until we have a complete utf-8 boundary.
+  const buf = Buffer.from(text);
+  const sliced = buf.subarray(0, budget).toString('utf8');
+  let out = sliced;
+  if (format === 'json') {
+    // Try to close the fence cleanly.
+    if (sliced.includes('```json')) {
+      out = sliced.replace(/```json[\s\S]*$/, '```json\n  /* truncated */\n```');
+    }
+  }
+  return out + marker;
+}

--- a/src/tools/diagnostics-format.ts
+++ b/src/tools/diagnostics-format.ts
@@ -345,6 +345,7 @@ function renderReasonBanner(reason: PartialReason, args: HeaderArgs): string[] {
 export interface RenderBatchResult {
   text: string;
   autoFallback?: 'by_file_to_summary';
+  hardTruncated?: boolean;
 }
 
 export interface RenderBatchOptions {
@@ -390,11 +391,13 @@ export function renderBatch(
 
   let text = headerWithGap + body;
   const finalSize = Buffer.byteLength(text);
+  let hardTruncated = false;
   if (finalSize > opts.maxBytes) {
     text = hardTruncate(text, opts.maxBytes, format);
+    hardTruncated = true;
   }
 
-  return autoFallback ? { text, autoFallback } : { text };
+  return { text, autoFallback, hardTruncated };
 }
 
 function renderBody(
@@ -548,7 +551,7 @@ function hardTruncate(text: string, maxBytes: number, format: RenderFormat): str
   if (format === 'json') {
     // Try to close the fence cleanly.
     if (sliced.includes('```json')) {
-      out = sliced.replace(/```json[\s\S]*$/, '```json\n  /* truncated */\n```');
+      out = sliced.includes('\n```') ? sliced : `${sliced}\n\`\`\``;
     }
   }
   return out + marker;

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -325,9 +325,9 @@ function renderWorkspaceDiagnosticsResult(
     header: tentativeHeader,
   });
 
-  // If by_file → summary fallback occurred, MAX_BYTES is the partial reason.
+  // If output exceeded max_bytes, MAX_BYTES is the partial reason.
   let finalText = rendered.text;
-  if (rendered.autoFallback === 'by_file_to_summary') {
+  if (rendered.autoFallback === 'by_file_to_summary' || rendered.hardTruncated) {
     partialReasons.add('MAX_BYTES');
     const finalHeader = renderHeader({
       status: 'PARTIAL',
@@ -352,13 +352,13 @@ function renderWorkspaceDiagnosticsResult(
       partialBuckets: batchResult.partialBucketKeys,
       completedBuckets: batchResult.completedBucketKeys,
       droppedCounts: batchResult.droppedCounts,
-      autoFallback: 'by_file_to_summary',
+      autoFallback: rendered.autoFallback,
       budgetMs: parsed.timeBudgetMs,
       resultsCollected: filterRes.counts.totalAfter,
       filesCollected: filesWithDiagnostics,
     });
     const reRendered = renderBatch(filterRes.filtered, {
-      format: 'summary',
+      format: rendered.autoFallback === 'by_file_to_summary' ? 'summary' : parsed.format,
       groupBy: parsed.groupBy,
       maxBytes: parsed.maxBytes,
       header: finalHeader,

--- a/src/tools/diagnostics.ts
+++ b/src/tools/diagnostics.ts
@@ -1,3 +1,16 @@
+import type {
+  BatchDiagnosticsRequest,
+  BatchDiagnosticsResult,
+  PartialReason,
+} from '../lsp/types.js';
+import {
+  type GroupBy,
+  type MinSeverity,
+  type RenderFormat,
+  filterDiagnostics,
+  renderBatch,
+  renderHeader,
+} from './diagnostics-format.js';
 import { resolvePath, textResult } from './helpers.js';
 import type { ToolDefinition } from './registry.js';
 
@@ -55,4 +68,309 @@ export const getDiagnosticsTool: ToolDefinition = {
   },
 };
 
-export const diagnosticsTools: ToolDefinition[] = [getDiagnosticsTool];
+export const getWorkspaceDiagnosticsTool: ToolDefinition = {
+  name: 'get_workspace_diagnostics',
+  description:
+    "Get diagnostics across many files in one call. Supply `paths`, `patterns` (glob, supports `!` negation), both (union), or neither (whole-workspace scope). Returns grouped diagnostics with totals, severities, top sources/codes, and per-file breakdowns. Uses LSP workspace/diagnostic when the server advertises it; otherwise falls back to per-file pull or didOpen-with-publishDiagnostics. Respects a wall-clock time budget and reports partial results clearly when truncated. Default min_severity is 'warning' for cleanup workflows.",
+  inputSchema: {
+    type: 'object',
+    additionalProperties: false,
+    properties: {
+      paths: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Explicit list of file paths. May be combined with `patterns`; the final set is the union.',
+      },
+      patterns: {
+        type: 'array',
+        items: { type: 'string' },
+        description:
+          'Glob patterns relative to `root`. Negation entries beginning with `!` are subtracted from the matched set (negation does NOT remove explicit `paths` entries).',
+      },
+      root: {
+        type: 'string',
+        description:
+          'Root directory for `patterns` resolution and workspace-scope walking. Defaults to process cwd.',
+      },
+      respect_gitignore: { type: 'boolean', default: true },
+      include_unopened: {
+        type: 'boolean',
+        default: true,
+        description:
+          'If false, diagnostics are only returned for files already open in their LSP server. With workspace scope this forces per-file pull mode and skips unopened files.',
+      },
+      min_severity: {
+        enum: ['error', 'warning', 'information', 'hint'],
+        default: 'warning',
+      },
+      sources: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Whitelist of diagnostic sources (e.g. ["typescript","eslint"]).',
+      },
+      exclude_codes: {
+        type: 'array',
+        items: { type: 'string' },
+        description: 'Blacklist of diagnostic codes (string-form).',
+      },
+      max_files: { type: 'integer', default: 1000, minimum: 1, maximum: 10000 },
+      max_diagnostics: { type: 'integer', default: 500, minimum: 1, maximum: 5000 },
+      max_bytes: { type: 'integer', default: 32768, minimum: 1024, maximum: 524288 },
+      time_budget_ms: { type: 'integer', default: 30000, minimum: 1000, maximum: 120000 },
+      format: { enum: ['summary', 'by_file', 'flat', 'json'], default: 'by_file' },
+      group_by: { enum: ['file', 'code', 'source', 'severity'], default: 'file' },
+    },
+  },
+  handler: async (args, client) => {
+    let parsed: ParsedWorkspaceArgs;
+    try {
+      parsed = parseWorkspaceDiagnosticsArgs(args);
+    } catch (error) {
+      // Enum validation failures surface as `isError: true`, while cap
+      // hits never set `isError`. The error message lists valid options
+      // for the offending field.
+      const result = textResult(
+        `get_workspace_diagnostics — ERROR\nError: ${error instanceof Error ? error.message : String(error)}`
+      );
+      return { ...result, isError: true };
+    }
+
+    let batchResult: BatchDiagnosticsResult;
+    try {
+      batchResult = await client.getDiagnosticsBatch(parsed.request);
+    } catch (error) {
+      // Real exceptions get surfaced as text — cap hits never throw.
+      return textResult(
+        `get_workspace_diagnostics — ERROR\nError: ${error instanceof Error ? error.message : String(error)}`
+      );
+    }
+
+    return renderWorkspaceDiagnosticsResult(batchResult, parsed);
+  },
+};
+
+const VALID_MIN_SEVERITIES = new Set<MinSeverity>(['error', 'warning', 'information', 'hint']);
+const VALID_FORMATS = new Set<RenderFormat>(['summary', 'by_file', 'flat', 'json']);
+const VALID_GROUP_BY = new Set<GroupBy>(['file', 'code', 'source', 'severity']);
+
+function validateEnum<T extends string>(
+  fieldName: string,
+  raw: unknown,
+  validSet: Set<T>,
+  defaultValue: T
+): T {
+  if (raw === undefined || raw === null) return defaultValue;
+  if (typeof raw !== 'string') {
+    throw new Error(
+      `invalid ${fieldName}: expected string, got ${typeof raw}. Valid options: ${Array.from(validSet).join(', ')}.`
+    );
+  }
+  if (!validSet.has(raw as T)) {
+    throw new Error(
+      `invalid ${fieldName}: "${raw}". Valid options: ${Array.from(validSet).join(', ')}.`
+    );
+  }
+  return raw as T;
+}
+
+export const diagnosticsTools: ToolDefinition[] = [getDiagnosticsTool, getWorkspaceDiagnosticsTool];
+
+// --- Helpers for get_workspace_diagnostics --------------------------------
+
+interface ParsedWorkspaceArgs {
+  request: BatchDiagnosticsRequest;
+  format: RenderFormat;
+  groupBy: GroupBy;
+  minSeverity: MinSeverity;
+  sources?: string[];
+  excludeCodes?: string[];
+  maxFiles: number;
+  maxDiagnostics: number;
+  maxBytes: number;
+  timeBudgetMs: number;
+  rootDir: string;
+}
+
+function parseWorkspaceDiagnosticsArgs(args: Record<string, unknown>): ParsedWorkspaceArgs {
+  const paths = Array.isArray(args.paths) ? (args.paths as unknown[]).map(String) : undefined;
+  const patterns = Array.isArray(args.patterns)
+    ? (args.patterns as unknown[]).map(String)
+    : undefined;
+  const root = typeof args.root === 'string' ? args.root : undefined;
+  const respectGitignore = args.respect_gitignore !== false;
+  const includeUnopened = args.include_unopened !== false;
+  const minSeverity = validateEnum<MinSeverity>(
+    'min_severity',
+    args.min_severity,
+    VALID_MIN_SEVERITIES,
+    'warning'
+  );
+  const sources = Array.isArray(args.sources) ? (args.sources as unknown[]).map(String) : undefined;
+  const excludeCodes = Array.isArray(args.exclude_codes)
+    ? (args.exclude_codes as unknown[]).map(String)
+    : undefined;
+  const maxFiles = clampInt(args.max_files, 1000, 1, 10000);
+  const maxDiagnostics = clampInt(args.max_diagnostics, 500, 1, 5000);
+  const maxBytes = clampInt(args.max_bytes, 32768, 1024, 524288);
+  const timeBudgetMs = clampInt(args.time_budget_ms, 30000, 1000, 120000);
+  const format = validateEnum<RenderFormat>('format', args.format, VALID_FORMATS, 'by_file');
+  const groupBy = validateEnum<GroupBy>('group_by', args.group_by, VALID_GROUP_BY, 'file');
+
+  return {
+    request: {
+      paths,
+      patterns,
+      root,
+      respectGitignore,
+      includeUnopened,
+      minSeverity,
+      sources,
+      excludeCodes,
+      maxFiles,
+      maxDiagnostics,
+      maxBytes,
+      timeBudgetMs,
+      format,
+      groupBy,
+    },
+    format,
+    groupBy,
+    minSeverity,
+    sources,
+    excludeCodes,
+    maxFiles,
+    maxDiagnostics,
+    maxBytes,
+    timeBudgetMs,
+    rootDir: root ?? process.cwd(),
+  };
+}
+
+function clampInt(raw: unknown, def: number, min: number, max: number): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return def;
+  const v = Math.floor(raw);
+  if (v < min) return min;
+  if (v > max) return max;
+  return v;
+}
+
+function renderWorkspaceDiagnosticsResult(
+  batchResult: BatchDiagnosticsResult,
+  parsed: ParsedWorkspaceArgs
+): ReturnType<typeof textResult> {
+  const filterRes = filterDiagnostics(batchResult.items, {
+    minSeverity: parsed.minSeverity,
+    sources: parsed.sources,
+    excludeCodes: parsed.excludeCodes,
+    maxDiagnostics: parsed.maxDiagnostics,
+  });
+
+  const partialReasons = new Set<PartialReason>(batchResult.partialReasons);
+  if (filterRes.counts.truncatedBy === 'MAX_DIAGNOSTICS') {
+    partialReasons.add('MAX_DIAGNOSTICS');
+  }
+
+  const filesWithDiagnostics = filterRes.filtered.filter((f) => f.items.length > 0).length;
+
+  // Compute initial status before considering MAX_BYTES auto-fallback.
+  let status: 'OK' | 'PARTIAL' | 'EMPTY';
+  if (
+    filterRes.counts.totalAfter === 0 &&
+    batchResult.filesConsidered === 0 &&
+    partialReasons.size === 0
+  ) {
+    status = 'EMPTY';
+  } else if (filterRes.counts.totalAfter === 0 && partialReasons.size === 0) {
+    status = 'OK';
+  } else if (partialReasons.size > 0) {
+    status = 'PARTIAL';
+  } else {
+    status = 'OK';
+  }
+
+  // First render attempt (pre-fallback) to detect MAX_BYTES.
+  const tentativeHeader = renderHeader({
+    status,
+    scope: batchResult.scope,
+    root: parsed.rootDir,
+    bucketCount: batchResult.buckets.length,
+    filesConsidered: batchResult.filesConsidered,
+    filesWithDiagnostics,
+    counts: filterRes.counts,
+    caps: {
+      max_files: parsed.maxFiles,
+      max_diagnostics: parsed.maxDiagnostics,
+      max_bytes: parsed.maxBytes,
+      time_budget_ms: parsed.timeBudgetMs,
+    },
+    filters: {
+      min_severity: parsed.minSeverity,
+      sources: parsed.sources,
+      exclude_codes: parsed.excludeCodes,
+    },
+    partialReasons: Array.from(partialReasons),
+    partialBuckets: batchResult.partialBucketKeys,
+    completedBuckets: batchResult.completedBucketKeys,
+    droppedCounts: batchResult.droppedCounts,
+    budgetMs: parsed.timeBudgetMs,
+    resultsCollected: filterRes.counts.totalAfter,
+    filesCollected: filesWithDiagnostics,
+  });
+
+  const rendered = renderBatch(filterRes.filtered, {
+    format: parsed.format,
+    groupBy: parsed.groupBy,
+    maxBytes: parsed.maxBytes,
+    header: tentativeHeader,
+  });
+
+  // If by_file → summary fallback occurred, MAX_BYTES is the partial reason.
+  let finalText = rendered.text;
+  if (rendered.autoFallback === 'by_file_to_summary') {
+    partialReasons.add('MAX_BYTES');
+    const finalHeader = renderHeader({
+      status: 'PARTIAL',
+      scope: batchResult.scope,
+      root: parsed.rootDir,
+      bucketCount: batchResult.buckets.length,
+      filesConsidered: batchResult.filesConsidered,
+      filesWithDiagnostics,
+      counts: filterRes.counts,
+      caps: {
+        max_files: parsed.maxFiles,
+        max_diagnostics: parsed.maxDiagnostics,
+        max_bytes: parsed.maxBytes,
+        time_budget_ms: parsed.timeBudgetMs,
+      },
+      filters: {
+        min_severity: parsed.minSeverity,
+        sources: parsed.sources,
+        exclude_codes: parsed.excludeCodes,
+      },
+      partialReasons: Array.from(partialReasons),
+      partialBuckets: batchResult.partialBucketKeys,
+      completedBuckets: batchResult.completedBucketKeys,
+      droppedCounts: batchResult.droppedCounts,
+      autoFallback: 'by_file_to_summary',
+      budgetMs: parsed.timeBudgetMs,
+      resultsCollected: filterRes.counts.totalAfter,
+      filesCollected: filesWithDiagnostics,
+    });
+    const reRendered = renderBatch(filterRes.filtered, {
+      format: 'summary',
+      groupBy: parsed.groupBy,
+      maxBytes: parsed.maxBytes,
+      header: finalHeader,
+    });
+    finalText = reRendered.text;
+  }
+
+  if (status === 'EMPTY') {
+    finalText += '\n\nNo files matched. Check `patterns` and `respect_gitignore`.';
+  } else if (status === 'OK' && filterRes.counts.totalAfter === 0) {
+    finalText += `\n\nNo diagnostics found across ${batchResult.filesConsidered} files. Workspace looks clean for filters (min_severity=${parsed.minSeverity}).`;
+  }
+
+  return textResult(finalText);
+}

--- a/src/tools/get-workspace-diagnostics.test.ts
+++ b/src/tools/get-workspace-diagnostics.test.ts
@@ -1,0 +1,308 @@
+import { describe, expect, it, jest } from 'bun:test';
+import type { LSPClient } from '../lsp-client.js';
+import type { BatchDiagnosticsRequest, BatchDiagnosticsResult, Diagnostic } from '../lsp/types.js';
+import { getWorkspaceDiagnosticsTool } from './diagnostics.js';
+
+/**
+ * Handler-level tests for `get_workspace_diagnostics`. We mock the
+ * `getDiagnosticsBatch` method on LSPClient so we can drive the handler's
+ * argument parsing, formatting, and cap-hit rendering without spawning
+ * any LSP servers.
+ */
+
+function mkDiag(opts: Partial<Diagnostic> = {}): Diagnostic {
+  return {
+    range: { start: { line: 0, character: 0 }, end: { line: 0, character: 1 } },
+    severity: 1,
+    message: 'oops',
+    source: 'mock',
+    code: 'E1',
+    ...opts,
+  };
+}
+
+function buildBatchResult(overrides: Partial<BatchDiagnosticsResult>): BatchDiagnosticsResult {
+  return {
+    items: [],
+    buckets: [],
+    filesConsidered: 0,
+    filesWithDiagnostics: 0,
+    scope: 'workspace',
+    rootDir: '/repo',
+    resolvedRoot: '/repo',
+    partial: false,
+    partialReasons: [],
+    droppedCounts: {
+      gitignored: 0,
+      notMatched: 0,
+      escaped: 0,
+      unreadable: 0,
+      maxFiles: 0,
+    },
+    completedBucketKeys: [],
+    partialBucketKeys: [],
+    ...overrides,
+  };
+}
+
+interface MockClient {
+  getDiagnosticsBatch: ReturnType<typeof jest.fn>;
+  capturedRequest?: BatchDiagnosticsRequest;
+}
+
+function createMockClient(result: BatchDiagnosticsResult): MockClient {
+  const mock: MockClient = {
+    getDiagnosticsBatch: jest.fn(),
+  };
+  mock.getDiagnosticsBatch.mockImplementation(async (req: BatchDiagnosticsRequest) => {
+    mock.capturedRequest = req;
+    return result;
+  });
+  return mock;
+}
+
+async function callHandler(
+  args: Record<string, unknown>,
+  client: MockClient
+): Promise<{ content: Array<{ type: 'text'; text: string }>; isError?: boolean }> {
+  return getWorkspaceDiagnosticsTool.handler(args, client as unknown as LSPClient);
+}
+
+describe('get_workspace_diagnostics MCP tool', () => {
+  it('emits OK status when there are zero diagnostics across some files', async () => {
+    const client = createMockClient(
+      buildBatchResult({
+        items: [],
+        filesConsidered: 5,
+      })
+    );
+    const result = await callHandler({}, client);
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('get_workspace_diagnostics — OK');
+    expect(text).toContain('No diagnostics found across 5 files');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('emits EMPTY status when no files matched', async () => {
+    const client = createMockClient(
+      buildBatchResult({
+        items: [],
+        filesConsidered: 0,
+      })
+    );
+    const result = await callHandler({}, client);
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('get_workspace_diagnostics — EMPTY');
+    expect(text).toContain('No files matched');
+  });
+
+  it('passes both paths and patterns through to the client (union)', async () => {
+    const client = createMockClient(buildBatchResult({}));
+    await callHandler(
+      {
+        paths: ['/repo/a.ts'],
+        patterns: ['src/**/*.ts'],
+      },
+      client
+    );
+    expect(client.capturedRequest?.paths).toEqual(['/repo/a.ts']);
+    expect(client.capturedRequest?.patterns).toEqual(['src/**/*.ts']);
+  });
+
+  it('passes include_unopened=false through to the client', async () => {
+    const client = createMockClient(buildBatchResult({}));
+    await callHandler({ include_unopened: false }, client);
+    expect(client.capturedRequest?.includeUnopened).toBe(false);
+  });
+
+  it('renders by_file format with diagnostics', async () => {
+    const client = createMockClient(
+      buildBatchResult({
+        items: [
+          {
+            uri: 'file:///a.ts',
+            items: [
+              mkDiag({ severity: 1, message: 'err-a', code: 'E1' }),
+              mkDiag({ severity: 2, message: 'warn-a', code: 'W1' }),
+            ],
+          },
+        ],
+        filesConsidered: 1,
+        filesWithDiagnostics: 1,
+      })
+    );
+    const result = await callHandler({ format: 'by_file' }, client);
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('a.ts');
+    expect(text).toContain('err-a');
+    expect(text).toContain('warn-a');
+  });
+
+  it('shows MAX_DIAGNOSTICS banner when filter truncates', async () => {
+    const items = Array.from({ length: 600 }, (_, i) =>
+      mkDiag({ severity: 1, message: `err${i}`, code: `C${i}` })
+    );
+    const client = createMockClient(
+      buildBatchResult({
+        items: [{ uri: 'file:///a.ts', items }],
+        filesConsidered: 1,
+        filesWithDiagnostics: 1,
+      })
+    );
+    const result = await callHandler({ format: 'summary' }, client);
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('Diagnostic cap hit (MAX_DIAGNOSTICS)');
+    expect(text).toContain('500/600');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('shows BUDGET banner when client returns partial with BUDGET reason', async () => {
+    const client = createMockClient(
+      buildBatchResult({
+        items: [{ uri: 'file:///a.ts', items: [mkDiag({ severity: 1, message: 'partial err' })] }],
+        partial: true,
+        partialReasons: ['BUDGET'],
+        filesConsidered: 5,
+        filesWithDiagnostics: 1,
+      })
+    );
+    const result = await callHandler({}, client);
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('get_workspace_diagnostics — PARTIAL');
+    expect(text).toContain('Wall-clock budget exhausted (BUDGET)');
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('shows MAX_FILES banner when client returns MAX_FILES partial reason', async () => {
+    const client = createMockClient(
+      buildBatchResult({
+        partial: true,
+        partialReasons: ['MAX_FILES'],
+        filesConsidered: 1000,
+        droppedCounts: {
+          gitignored: 0,
+          notMatched: 0,
+          escaped: 0,
+          unreadable: 0,
+          maxFiles: 3823,
+        },
+      })
+    );
+    const result = await callHandler({}, client);
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('File cap hit (MAX_FILES)');
+    expect(text).toContain('truncated input from 4823 to 1000');
+  });
+
+  it('shows SERVER_CRASH banner', async () => {
+    const client = createMockClient(
+      buildBatchResult({
+        partial: true,
+        partialReasons: ['SERVER_CRASH'],
+        partialBucketKeys: ['pylsp@/repo'],
+      })
+    );
+    const result = await callHandler({}, client);
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('Server crash (SERVER_CRASH)');
+    expect(text).toContain('pylsp@/repo');
+  });
+
+  it('clamps invalid integer args to defaults', async () => {
+    const client = createMockClient(buildBatchResult({}));
+    await callHandler(
+      {
+        max_files: 999999, // above the schema max 10000
+        max_diagnostics: -5, // below minimum 1
+        max_bytes: 'not a number',
+        time_budget_ms: 1, // below minimum 1000
+      },
+      client
+    );
+    expect(client.capturedRequest?.maxFiles).toBe(10000);
+    expect(client.capturedRequest?.maxDiagnostics).toBe(1);
+    expect(client.capturedRequest?.maxBytes).toBe(32768);
+    expect(client.capturedRequest?.timeBudgetMs).toBe(1000);
+  });
+
+  it('never sets isError=true even when batch fully crashes', async () => {
+    const client: MockClient = {
+      getDiagnosticsBatch: jest.fn().mockResolvedValue(
+        buildBatchResult({
+          partial: true,
+          partialReasons: ['SERVER_CRASH'],
+        })
+      ),
+    };
+    const result = await callHandler({}, client);
+    expect(result.isError).toBeUndefined();
+  });
+
+  it('surfaces unexpected exceptions as text without isError', async () => {
+    const client: MockClient = {
+      getDiagnosticsBatch: jest.fn().mockRejectedValue(new Error('unexpected')),
+    };
+    const result = await callHandler({}, client);
+    expect(result.isError).toBeUndefined();
+    expect(result.content[0]?.text ?? '').toContain('get_workspace_diagnostics — ERROR');
+    expect(result.content[0]?.text ?? '').toContain('unexpected');
+  });
+
+  it('renders flat format with messageLen annotation', async () => {
+    const client = createMockClient(
+      buildBatchResult({
+        items: [
+          {
+            uri: 'file:///a.ts',
+            items: [mkDiag({ severity: 1, message: 'flat test' })],
+          },
+        ],
+        filesConsidered: 1,
+        filesWithDiagnostics: 1,
+      })
+    );
+    const result = await callHandler({ format: 'flat' }, client);
+    expect(result.content[0]?.text ?? '').toContain('messageLen:');
+  });
+
+  it('passes min_severity through to the client', async () => {
+    const client = createMockClient(buildBatchResult({}));
+    await callHandler({ min_severity: 'error' }, client);
+    expect(client.capturedRequest?.minSeverity).toBe('error');
+  });
+
+  it('passes sources whitelist through to the client', async () => {
+    const client = createMockClient(buildBatchResult({}));
+    await callHandler({ sources: ['typescript', 'eslint'] }, client);
+    expect(client.capturedRequest?.sources).toEqual(['typescript', 'eslint']);
+  });
+
+  it('returns isError=true with a clear message on invalid min_severity', async () => {
+    const client = createMockClient(buildBatchResult({}));
+    const result = await callHandler({ min_severity: 'critical' }, client);
+    expect(result.isError).toBe(true);
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('invalid min_severity');
+    expect(text).toContain('error, warning, information, hint');
+    // Must not have called the client when validation fails.
+    expect(client.getDiagnosticsBatch).not.toHaveBeenCalled();
+  });
+
+  it('returns isError=true with a clear message on invalid format', async () => {
+    const client = createMockClient(buildBatchResult({}));
+    const result = await callHandler({ format: 'xml' }, client);
+    expect(result.isError).toBe(true);
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('invalid format');
+    expect(text).toContain('summary, by_file, flat, json');
+  });
+
+  it('returns isError=true with a clear message on invalid group_by', async () => {
+    const client = createMockClient(buildBatchResult({}));
+    const result = await callHandler({ group_by: 'planet' }, client);
+    expect(result.isError).toBe(true);
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('invalid group_by');
+    expect(text).toContain('file, code, source, severity');
+  });
+});

--- a/src/tools/get-workspace-diagnostics.test.ts
+++ b/src/tools/get-workspace-diagnostics.test.ts
@@ -208,6 +208,25 @@ describe('get_workspace_diagnostics MCP tool', () => {
     expect(text).toContain('pylsp@/repo');
   });
 
+  it('shows MAX_BYTES banner when summary output is hard-truncated', async () => {
+    const items = Array.from({ length: 200 }, (_, i) => ({
+      uri: `file:///very/long/path/file-${i}.ts`,
+      items: [mkDiag({ severity: 1, message: `err${i}`, code: `C${i}` })],
+    }));
+    const client = createMockClient(
+      buildBatchResult({
+        items,
+        filesConsidered: items.length,
+        filesWithDiagnostics: items.length,
+      })
+    );
+    const result = await callHandler({ format: 'summary', max_bytes: 1024 }, client);
+    const text = result.content[0]?.text ?? '';
+    expect(text).toContain('get_workspace_diagnostics — PARTIAL');
+    expect(text).toContain('Output size cap hit (MAX_BYTES)');
+    expect(text).toContain('output truncated');
+  });
+
   it('clamps invalid integer args to defaults', async () => {
     const client = createMockClient(buildBatchResult({}));
     await callHandler(


### PR DESCRIPTION
## Summary

Adds a new `get_workspace_diagnostics` MCP tool that returns LSP diagnostics for many files in a single call — designed for cleanup workflows on projects with hundreds of diagnostics across thousands of files. The existing single-file `get_diagnostics` tool is preserved unchanged.

<img width="2158" height="812" alt="image" src="https://github.com/user-attachments/assets/9f6d9465-cc6b-479d-8c8a-ef1e79b704da" />

Delivered as three reviewable commits:

- **`4d00b1a` PR1 — LSP plumbing (additive).** Capture `serverCapabilities` from `initialize`, declare matching client capabilities, add `$/cancelRequest` with `RequestCancelledError` + race-guarded settlement, add `$/progress` notification routing via a token-keyed handler registry, add `DocumentManager.ensureOpenAsync`/`closeDocument` (and a deduped private `openWithContent` helper), add `ServerState.inFlightBatchCount` with a deferred-restart guard, and add `DiagnosticsCache.setResultId`/`getResultId`. No call sites from existing code paths — strictly additive.
- **`72015e9` PR2 — Tool + batch ops + globs.** New `get_workspace_diagnostics` MCP tool accepting `paths`, `patterns` (globs with `!` negation), both (union), or neither (whole-workspace scope). Three batch LSP ops (`workspaceDiagnostic`, `perFilePullBatch`, `pushFallbackBatch`) sharing a `runPerFileBucket` helper, all using a new `JsonRpcTransport.sendCancellableRequest` so the wall-clock budget can actually cancel in-flight LSP requests via `$/cancelRequest`. New `LSPRequestTimeoutError` so per-request timeouts classify as BUDGET, not SERVER_CRASH. Per-bucket strategy selection via the PR1 capability helpers. Global PARTIAL aggregator with explicit priority `SERVER_CRASH > BUDGET > MAX_FILES > MAX_DIAGNOSTICS > MAX_BYTES`. Output formatter with by_file/summary/flat/json renderers, 240-char message clipping, `by_file → summary` auto-fallback when projected output exceeds `max_bytes`. New `src/file-glob.ts` (picomatch + gitignore + negation + root-escape + depth cap). Vue/Pyright adapters extended with `workspace/diagnostic` upper bounds. Runtime dep `picomatch@^4.0.4` (zero-dep).
- **`bfb7fd9` PR3 — Result-id reuse + docs.** `workspaceDiagnostic` now sources `previousResultIds` from `cache.listResultIds()`, so the second call against unchanged code can short-circuit via `kind:'unchanged'`. Partial-flush paths (BUDGET, SERVER_CRASH) also populate the cache so a cancelled call still warms it for next time. README documents the new tool with three usage examples plus cap-hit messaging guidance.

## Defaults

Tuned for the cleanup use case ("I have hundreds of warnings; show me the picture"):

- `min_severity='warning'` (use `'error'` to focus only on errors)
- `max_diagnostics=500`, `max_bytes=32768`, `max_files=1000`
- `time_budget_ms=30000` (max 120000)
- `format='by_file'`, `group_by='file'`
- Per-file concurrency = 2 (single-threaded LSP servers like tsserver/pyright don't benefit from more)

Caps never produce `isError: true`; they produce a `PARTIAL` header that names exactly which cap fired (`BUDGET`, `MAX_FILES`, `MAX_DIAGNOSTICS`, `MAX_BYTES`, `SERVER_CRASH`) with explicit "do NOT retry with the same args — narrow scope" guidance. Only invalid enum values (e.g. a misspelled `format`) return `isError: true`.

## Test plan

- [x] `bun test` — 353 pass / 5 skip / 0 fail across 32 files (was 230 pass before this branch)
- [x] `bun run typecheck` — clean
- [x] `bun run lint` — clean (Biome)
- [x] `bun run format` — clean
- [x] Single-file `get_diagnostics` tool output pinned byte-for-byte (`src/get-diagnostics.tool-rendering.test.ts` + new op-level test `src/lsp/operations.get-diagnostics.test.ts`)
- [x] New test files: capabilities, cancel, progress, document-manager close, server-manager capabilities, server-manager deferred-restart, op-level get_diagnostics regression, operations.batch, operations.result-id, diagnostics-format, get-workspace-diagnostics, file-glob, lsp-client.batch

> This PR was created by **Megamind** agent using Claude
